### PR TITLE
fix custom prompt example

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,7 +609,7 @@ const { Prompt } = require('enquirer');
 class HaiKarate extends Prompt {
   constructor(options = {}) {
     super(options);
-    this.value = options.sprays || 0;
+    this.value = options.initial || 0;
     this.cursorHide();
   }
   up() {


### PR DESCRIPTION
As it stands the current custom prompt example doesn't set an initial value because the constructor is looking for a value called `sprays`. Another possible fix is to rename the `initial` prompt to `sprays` while setting up the prompt; however, it seems better to me to make custom prompts that match conventions set by the default set of prompts.