### PR TITLE
ci: test Node.js 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,4 @@ language: node_js
 node_js:
   - 'node'
   - '10'
-  - '9'
   - '8'


### PR DESCRIPTION
Node.js 9 has already reached its EOL and we should only test the current LTS and stable branches. See https://github.com/nodejs/Release/blob/master/README.md