### PR TITLE
allow returning false in validation

### DIFF
--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -114,7 +114,7 @@ class Prompt extends Events {
 
     let result = this.state.error || await this.validate(this.value, this.state);
     if (result !== true) {
-      let error = typeof result === 'string' ? this.symbols.pointer + ' ' + result.trim() : 'Your input is invalid.';
+      let error = this.symbols.pointer + ' ' + (typeof result === 'string' ? result.trim() : 'Invalid input');
       this.state.error = '\n' + this.styles.danger(error);
       this.state.submitted = false;
       await this.render();

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -114,7 +114,7 @@ class Prompt extends Events {
 
     let result = this.state.error || await this.validate(this.value, this.state);
     if (result !== true) {
-      let error = this.symbols.pointer + ' ' + result.trim();
+      let error = typeof result === 'string' ? this.symbols.pointer + ' ' + result.trim() : 'Your input is invalid.';
       this.state.error = '\n' + this.styles.danger(error);
       this.state.submitted = false;
       await this.render();


### PR DESCRIPTION
If the `valiate` function of a question returns `false`, an error will occur. This PR fixes this problem.