### PR TITLE
Add type definitions to files published to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "license": "MIT",
   "files": [
     "index.js",
+    "index.d.ts",
     "lib"
   ],
   "main": "index.js",


### PR DESCRIPTION
Currently, the TypeScript types are not included in the npm package.
This PR adds the files to the files array in package.json.