### PR TITLE
Fix: prompt in child_process

### DIFF
--- a/lib/keypress.js
+++ b/lib/keypress.js
@@ -187,7 +187,7 @@ const keypress = (s = '', event = {}) => {
 };
 
 keypress.listen = (stream, onKeypress) => {
-  if (!stream || typeof stream.isRaw !== 'boolean') {
+  if (!stream || (stream !== process.stdin && !stream.isTTY)) {
     throw new Error('Invalid stream passed');
   }
 
@@ -197,12 +197,12 @@ keypress.listen = (stream, onKeypress) => {
   let on = (buf, key) => onKeypress(buf, keypress(buf, key), rl);
   let isRaw = stream.isRaw;
 
-  stream.setRawMode(true);
+  if (stream.isTTY) stream.setRawMode(true);
   stream.on('keypress', on);
   rl.resume();
 
   let off = () => {
-    stream.setRawMode(isRaw);
+    if (stream.isTTY) stream.setRawMode(isRaw);
     stream.removeListener('keypress', on);
     rl.pause();
     rl.close();

--- a/test/prompt.childprocess.js
+++ b/test/prompt.childprocess.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const path = require('path');
+const assert = require('assert');
+const { fork } = require('child_process');
+
+describe('child_process', function() {
+  it('should works in child_process', cb => {
+    let cmd = fork(path.resolve(__dirname, './support/child_process.js'), [], {
+      silent: true,
+    });
+
+    let stdout = '';
+    let stderr = '';
+    cmd.stdout.on('data', buf => {
+      let data = buf.toString();
+      stdout += data;
+      if (data.includes('color')) cmd.stdin.write('orange\n');
+    });
+
+    cmd.stderr.on('data', buf => {
+      stderr += buf.toString();
+    });
+
+    cmd.on('close', () => {
+      assert(!stderr);
+      assert(stdout.includes('color: \'orange\''));
+      cb();
+    });
+  });
+});

--- a/test/support/child_process.js
+++ b/test/support/child_process.js
@@ -1,0 +1,11 @@
+const { prompt } = require('../..');
+
+prompt({
+  type: 'input',
+  name: 'color',
+  message: 'Favorite color?'
+})
+.then(answers => {
+  console.info(answers);
+  process.exit(0);
+});


### PR DESCRIPTION
Hi, enquirer is awesome but when I use it in child_process, it throw this error

```
(node:81812) UnhandledPromiseRejectionWarning: Error: Invalid stream passed
    at Function.keypress.listen (/Users/wanghx/Workspace/larva-team/common-bin-plus/node_modules/enquirer/lib/keypress.js:191:11)
    at Input.start (/Users/wanghx/Workspace/larva-team/common-bin-plus/node_modules/enquirer/lib/prompt.js:169:28)
    at Input.initialize (/Users/wanghx/Workspace/larva-team/common-bin-plus/node_modules/enquirer/lib/prompt.js:196:16)
    at Promise (/Users/wanghx/Workspace/larva-team/common-bin-plus/node_modules/enquirer/lib/prompt.js:212:18)
    at process._tickCallback (internal/process/next_tick.js:68:7)
    at Function.Module.runMain (internal/modules/cjs/loader.js:744:11)
    at startup (internal/bootstrap/node.js:285:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:739:3)
```

And I check the code and found that you are verifying `stdin.isRaw` in `keypress.listen` ( https://github.com/enquirer/enquirer/blob/master/lib/keypress.js#L190 ) . When the code is running in `child_process` and `stdio` is `pipe`, `process.stdin` will  be instance of `net.Socket` instead of `tty.ReadStream` and it doesn't has property `isRaw`. ( 
see https://github.com/nodejs/node/blob/master/lib/internal/process/stdio.js#L58 ) , so the error was thrown.

I think it maybe need a compatibility processing?

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->

no

##### Description of change
<!-- Provide a description of the change below this comment. -->

- using `stream.isTTY` instead of `stream.isRaw`.
- throw error only in situation that stream is not `process.stdin` and `tty.ReadStream`.
- check whether is tty before invoking `setRawMode` method.
