### PR TITLE
v3.0

### DIFF
--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -23,7 +23,7 @@ class Prompt extends Events {
     theme(this);
     timer(this);
     this.state = new State(this);
-    this.initial = [options.initial, options.default].find(v => v != null);
+    this.initial = options.initial;
     this.stdout = options.stdout || process.stdout;
     this.stdin = options.stdin || process.stdin;
     this.scale = options.scale || 1;

--- a/lib/prompts/confirm.js
+++ b/lib/prompts/confirm.js
@@ -1,13 +1,5 @@
 'use strict';
 
 const BooleanPrompt = require('../types/boolean');
-
-class ConfirmPrompt extends BooleanPrompt {
-  constructor(options) {
-    super(options);
-    this.default = this.options.default || (this.initial ? '(Y/n)' : '(y/N)');
-  }
-}
-
+class ConfirmPrompt extends BooleanPrompt {}
 module.exports = ConfirmPrompt;
-

--- a/lib/types/boolean.js
+++ b/lib/types/boolean.js
@@ -7,6 +7,7 @@ class BooleanPrompt extends Prompt {
   constructor(options) {
     super(options);
     this.cursorHide();
+    this.default = this.options.default || (this.initial ? '(Y/n)' : '(y/N)');
   }
 
   async initialize() {
@@ -60,7 +61,7 @@ class BooleanPrompt extends Prompt {
     let msg = await this.message();
     let hint = this.styles.muted(this.default);
 
-    let promptLine = [prefix, msg, hint, sep].filter(Boolean).join(' ');
+    let promptLine = [prefix, msg, sep, hint].filter(Boolean).join(' ');
     this.state.prompt = promptLine;
 
     let header = await this.header();


### PR DESCRIPTION
## v3.0 Tasks

### Features

- [ ] Dynamically insert choices. See https://github.com/enquirer/enquirer/issues/30 and https://github.com/enquirer/enquirer/issues/33#issuecomment-438665252.
- [ ] Static headers for array prompts (below prompt message, but above list). See https://github.com/enquirer/enquirer/issues/122
- [ ] Static footers for array prompts (above prompt footer)
- [ ] Combine scale prompts. See https://github.com/enquirer/enquirer/issues/42
- [ ] Support input and choices in form prompts. See https://github.com/enquirer/enquirer/issues/65. 
- [ ] Allow `initial` value to be editable, as if it was entered by the user. See https://github.com/enquirer/enquirer/issues/66. 
- [ ] Update Typings. See https://github.com/enquirer/enquirer/issues/83, https://github.com/enquirer/enquirer/issues/95
- [ ] Rethink choice "roles": https://github.com/enquirer/enquirer/issues/34
- [ ] Number prompt is not respecting `min` and `max` during validation. See https://github.com/enquirer/enquirer/issues/104.
- [ ] Fix `skip`. See https://github.com/enquirer/enquirer/issues/105.


## Bugs

- [ ] Autocomplete bug on WSL bash console (not on native windows cmd). See https://github.com/enquirer/enquirer/issues/88.
- [x] `options.default` should follow the separator, not precede. See https://github.com/enquirer/enquirer/issues/103.

## Typescript Bugs

- [ ] Missing limit field in ArrayPromptOptions interface declaration. See https://github.com/enquirer/enquirer/issues/95

## Recipes and docs

- [ ] https://github.com/enquirer/enquirer/issues/33
- [ ] https://github.com/enquirer/enquirer/issues/32#issuecomment-437196256
- [ ] Reference perf comparisons: https://github.com/enquirer/enquirer/issues/22
- [ ] Update docs regarding "direct swap" for Inquirer. See https://github.com/enquirer/enquirer/issues/40
- [ ] Explain how to handle recursive calls. See https://github.com/enquirer/enquirer/issues/70
