### PR TITLE
Fix skip functionality

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,6 +105,13 @@ class Enquirer extends Events {
     assert(this.prompts[type], `Prompt "${type}" is not registered`);
 
     let prompt = new this.prompts[type](opts);
+
+    if (await prompt.skip()) {
+      // Don't emit anything and return nothing if the question should be skipped
+      // XXX: Maybe we should emit a "skip" event?
+      return;
+    }
+
     let value = get(this.answers, name);
 
     prompt.state.answers = this.answers;

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -183,11 +183,11 @@ class Prompt extends Events {
   }
 
   async skip() {
-    this.skipped = this.options.skip === true;
+    let skipped = this.options.skip === true;
     if (typeof this.options.skip === 'function') {
-      this.skipped = await this.options.skip.call(this, this.name, this.value);
+      skipped = await this.options.skip.call(this, this.name, this.value);
     }
-    return this.skipped;
+    return skipped;
   }
 
   async initialize() {
@@ -229,10 +229,6 @@ class Prompt extends Events {
     return new Promise(async(resolve, reject) => {
       this.once('submit', resolve);
       this.once('cancel', reject);
-      if (await this.skip()) {
-        this.render = () => {};
-        return this.submit();
-      }
       await this.initialize();
       this.emit('run');
     });

--- a/test/enquirer.js
+++ b/test/enquirer.js
@@ -51,13 +51,15 @@ describe('Enquirer', function() {
       });
     });
 
-    it('should run an array of questions', cb => {
+    it('should run an array of questions and skip one question', cb => {
       enquirer = new Enquirer({ show: false });
       enquirer.on('prompt', prompt => {
         if (prompt.name === 'color') {
           prompt.value = 'blue';
-        } else {
+        } else if (prompt.name === 'name') {
           prompt.value = 'Brian';
+        } else {
+          prompt.value = 1
         }
         prompt.submit();
       });
@@ -69,12 +71,19 @@ describe('Enquirer', function() {
       },
       {
         type: 'input',
+        name: 'age',
+        message: "What's your age?",
+        skip: true
+      },
+      {
+        type: 'input',
         name: 'name',
         message: 'What is your name?'
       }])
       .then(answers => {
         assert.equal(answers.color, 'blue');
         assert.equal(answers.name, 'Brian');
+        assert.equal(answers.age, undefined);
         cb();
       });
     });
@@ -104,7 +113,7 @@ describe('Enquirer', function() {
     it('should run an array of questions', cb => {
       const { prompt } = Enquirer;
       prompt.on('prompt', prompt => {
-        prompt.value = prompt.name === 'color' ? 'blue' : 'Brian';
+        prompt.value = prompt.name === 'color' ? 'blue' : prompt.name === 'name' ? 'Brian': 1;
         prompt.submit();
       });
 
@@ -116,6 +125,12 @@ describe('Enquirer', function() {
       },
       {
         type: 'input',
+        name: 'age',
+        message: "What's your age?",
+        skip: true
+      },
+      {
+        type: 'input',
         name: 'name',
         message: 'What is your name?',
         show: false
@@ -123,6 +138,7 @@ describe('Enquirer', function() {
       .then(answers => {
         assert.equal(answers.color, 'blue');
         assert.equal(answers.name, 'Brian');
+        assert.equal(answers.age, undefined);
         cb();
       });
     });


### PR DESCRIPTION
Hey,

The skip functionality didn't work for me, whenever I used skip in a prompt when providing multiple prompts it would just "quit". I wouldn't even get any results back from `await prompt(questions)`, really weird.

Anyways, here's a PR where the skip logic is changed and it resembled how it was before version 2.2.0 but now I do the `skip` check in `ask` and are using `await prompt.skip()`.

Also added a question with skip to the questions array tests.