### PR TITLE
Add vim direction keypresses

### DIFF
--- a/lib/combos.js
+++ b/lib/combos.js
@@ -71,5 +71,10 @@ exports.keys = {
   return: 'submit',
   right: 'right',
   tab: 'next',
-  up: 'up'
+  up: 'up',
+  // For the vim users
+  h: 'left',
+  j: 'down',
+  k: 'up',
+  l: 'right'
 };


### PR DESCRIPTION
Firstly, thank you for this awesome project!

My usage has left me wanting something though - vim bindings for directional movement.

As a heavy vim user, I find directional movement more convenient using tha classic `vim` bindings `hjkl` than reaching over for the arrow keys. 

Are we able to add vim bindings to `enquirer`?

I took a stab at adding these keypresses in this pull request - but is this the correct way to add support?