### PR TITLE
add: list/option-no-empty-string.js

### DIFF
--- a/examples/list/option-no-empty-string.js
+++ b/examples/list/option-no-empty-string.js
@@ -1,0 +1,14 @@
+'use strict';
+/* This example filters out all the empty string added in the result */
+const { List } = require('enquirer');
+const prompt = new List({
+  name: 'keywords',
+  message: 'Type comma-separated keywords',
+  result(answers) {
+    return answers.filter(Boolean);
+  }
+});
+
+prompt.run()
+  .then(answer => console.log('Answer:', answer))
+  .catch(console.error);


### PR DESCRIPTION
Add a list prompt example that filters out all the empty strings in the resulting array.
Closes #174