### PR TITLE
fix: examples/survey/prompt.js

### DIFF
--- a/lib/styles.js
+++ b/lib/styles.js
@@ -58,6 +58,13 @@ const styles = {
     return this._em || this.primary.underline;
   },
 
+  set heading(custom) {
+    this._heading = custom;
+  },
+  get heading() {
+    return this._heading || this.muted.underline;
+  },
+
   /**
    * Statuses
    */


### PR DESCRIPTION
Add setter and getter functions for heading in lib/styles.js which is required by the survey prompt.

Resolves #140