### PR TITLE
fix: lib/prompts/editable.js

### DIFF
--- a/lib/prompts/editable.js
+++ b/lib/prompts/editable.js
@@ -33,6 +33,10 @@ class Editable extends Select {
     return this.focused.editable ? this.append(char) : super.space();
   }
 
+  number(char) {
+    return this.focused.editable ? this.append(char) : super.number(char);
+  }
+
   next() {
     return this.focused.editable ? form.next.call(this) : super.next();
   }


### PR DESCRIPTION
Add number() function to accept numeral input in 'editable' prompts.
Hence, fix a bug in examples/editable/prompt.js, mentioned in #139 