### PR TITLE
feat: Add two-factor authentication using TOTP

### DIFF
--- a/examples/enquirer/2-factor-authentication/config.js
+++ b/examples/enquirer/2-factor-authentication/config.js
@@ -1,0 +1,14 @@
+const USERNAME = 'rajat';
+const PASSWORD = 'abc123';
+
+/*
+ * Add this secret to your Google Authenticator app.
+ * To generate a new secret code, run ./generateSecret.js
+ */
+const SECRET = '72JTCPPOO2JRL53E';
+
+module.exports = {
+  SECRET,
+  USERNAME,
+  PASSWORD
+};

--- a/examples/enquirer/2-factor-authentication/generateSecret.js
+++ b/examples/enquirer/2-factor-authentication/generateSecret.js
@@ -1,0 +1,16 @@
+const crypto = require('crypto');
+const base32 = require('hi-base32');
+
+/*
+ * Use this function to generate a secret that will
+ * be shared with a client app, like Google Authenticator.
+ * Then replace the SECRET constant in `./config.js` with
+ * the generated secret for this prompt example to run correctly.
+ */
+function generateSecret(length = 20) {
+  const randomBuffer = crypto.randomBytes(length);
+  return base32.encode(randomBuffer).replace(/=/g, '');
+}
+
+console.log(`Secret: ${generateSecret(10)}`);
+console.log('Use this secret to add a new account in Google Authenticator app. Also, update the value of SECRET in config.js with this new secret.');

--- a/examples/enquirer/2-factor-authentication/hotp.js
+++ b/examples/enquirer/2-factor-authentication/hotp.js
@@ -1,0 +1,49 @@
+const crypto = require('crypto');
+const base32 = require('hi-base32');
+
+/*
+ * This is an implementation of HMAC-Based One Time Password (HOTP) algorithm
+ * specified in RFC 4226 (https://tools.ietf.org/html/rfc4226)
+ */
+function generateHOTP(secret, counter, otpLength = 6, hmacAlgorithm = 'sha1') {
+  if (!secret) {
+    throw new Error('Secret is required');
+  }
+
+  if (!counter) {
+    throw new Error('Counter is required');
+  }
+
+  const decodedSecret = base32.decode.asBytes(secret);
+  const buffer = Buffer.alloc(8);
+  for (let i = 0; i < 8; i++) {
+    buffer[7 - i] = counter & 0xff;
+    counter = counter >> 8;
+  }
+
+  // Step 1: Generate an HMAC-SHA-1 value
+  const hmac = crypto.createHmac(hmacAlgorithm, Buffer.from(decodedSecret));
+  hmac.update(buffer);
+  const hmacResult = hmac.digest();
+
+  // Step 2: Generate a 4-byte string (Dynamic Truncation)
+  const code = dynamicTruncationFn(hmacResult);
+
+  // Step 3: Compute an HOTP value
+  return code % 10 ** otpLength;
+}
+
+function dynamicTruncationFn(hmacValue) {
+  const offset = hmacValue[hmacValue.length - 1] & 0xf;
+
+  return (
+    ((hmacValue[offset] & 0x7f) << 24) |
+    ((hmacValue[offset + 1] & 0xff) << 16) |
+    ((hmacValue[offset + 2] & 0xff) << 8) |
+    (hmacValue[offset + 3] & 0xff)
+  );
+}
+
+module.exports = {
+  generateHOTP
+};

--- a/examples/enquirer/2-factor-authentication/index.js
+++ b/examples/enquirer/2-factor-authentication/index.js
@@ -1,0 +1,6 @@
+const { prompt } = require('enquirer');
+const questions = require('./questions');
+
+prompt(questions)
+  .then(answers => console.log(answers))
+  .catch(console.log);

--- a/examples/enquirer/2-factor-authentication/questions.js
+++ b/examples/enquirer/2-factor-authentication/questions.js
@@ -1,0 +1,29 @@
+'use strict';
+const { verifyTOTP } = require('./totp');
+const config = require('./config');
+
+module.exports = [
+  {
+    type: 'text',
+    name: 'username',
+    message: 'Enter your username: ',
+    initial: config.USERNAME
+  },
+  {
+    type: 'password',
+    name: 'password',
+    message: 'Enter your password: ',
+    initial: config.PASSWORD,
+    validate: () => true
+  },
+  {
+    type: 'text',
+    name: 'otp',
+    message: 'Enter OTP from Google Authenticator app: ',
+    initial: () => '',
+    validate: input => {
+      return verifyTOTP(input, config.SECRET) ? true : 'Incorrect OTP. Please retry.';
+    },
+    result: () => 'Correct OTP'
+  }
+];

--- a/examples/enquirer/2-factor-authentication/totp.js
+++ b/examples/enquirer/2-factor-authentication/totp.js
@@ -1,0 +1,53 @@
+const { generateHOTP } = require('./hotp');
+
+/*
+ * This is an implementation of Time-Based One Time Password (TOTP) algorithm
+ * specified in RFC 6238 (https://tools.ietf.org/html/rfc6238)
+ */
+function generateTOTP(secret, window = 0, timeStepInSeconds = 30, initialTime = 0, otpLength = 6) {
+  if (!secret) {
+    throw new Error('Secret is required');
+  }
+
+  const currentTime = Date.now();
+  const timeStep = timeStepInSeconds * 1000;
+  const counter = Math.floor((currentTime - initialTime) / timeStep);
+  return generateHOTP(secret, counter + window, otpLength);
+}
+
+/*
+ * This function verifies the validity of OTP (token) entered by the user
+ * from the Google Authenticator app.
+ * The secret passed here as argument must match with the secret in the
+ * authenticator app.
+ */
+function verifyTOTP(token, secret, window = 1) {
+  try {
+    token = parseInt(token, 10);
+    if (isNaN(token)) {
+      throw new Error();
+    }
+  } catch (e) {
+    console.error('Invalid token');
+    return false;
+  }
+
+  if (Math.abs(+window) > 10) {
+    console.error('Window size is too large');
+    return false;
+  }
+
+  for (let errorWindow = -window; errorWindow <= +window; errorWindow++) {
+    const totp = generateTOTP(secret, errorWindow);
+    if (token === totp) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+module.exports = {
+  generateTOTP,
+  verifyTOTP
+};

--- a/examples/package.json
+++ b/examples/package.json
@@ -3,10 +3,11 @@
   "version": "0.0.0",
   "private": true,
   "devDependencies": {
-    "enquirer": "file:..",
     "ansi-colors": "^3.2.1",
     "cli-spinners": "^1.3.1",
     "data-store": "^3.1.0",
+    "enquirer": "file:..",
+    "hi-base32": "^0.5.0",
     "semver": "^5.6.0",
     "yosay": "^2.0.2"
   }


### PR DESCRIPTION
Adds a new prompt example to demonstrate two-factor authentication using OTP generated by Google Authenticator.

Contains code to generate:
- Time-Based One Time Password (TOTP) using the algorithm specified in [RFC 6238](https://tools.ietf.org/html/rfc6238)
- HMAC-based One Time Password (HOTP) using the algorithm specified in [RFC 4226](https://tools.ietf.org/html/rfc4226)

The prompt example verifies Time-Based OTP generated by any Google Authenticator app using a shared secret.

A new secret can also be generated from the code.