### PR TITLE
Fixes prompt method TypeScript type declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -140,7 +140,7 @@ declare namespace Enquirer {
       | PromptOptions
       | ((this: Enquirer) => PromptOptions)
       | (PromptOptions | ((this: Enquirer) => PromptOptions))[]
-  ): Promise<T>;
+  ): Promise<{ [key: string]: string }>;
 
   class Prompt extends BasePrompt {}
 }


### PR DESCRIPTION
Currently, basic usage of the `prompt` method throws TypeScript compiler errors since the `object` type doesn't allow dynamic properties.

<img width="724" alt="Screen Shot 2019-08-01 at 10 05 41 PM" src="https://user-images.githubusercontent.com/6406400/62345944-1d909c80-b4a9-11e9-964f-7c04b765772a.png">

[TypeScript playground example reproducing the core issue with `object` type.](https://www.typescriptlang.org/play/#code/PTAEGMHsFsAcEsA2BTATqNrKoM4CgoA7HAF1EgCMArALnOuXDIF5QBvAXwG49KqA6AGaRIoVgHJhkcTzwhQAQ0SJQAcxEATApGJkpdNqADaAa2QBPOqVTxCqgLpWSNu6A5j23PFP4UF6CQoddRk8IA)

<img width="552" alt="Screen Shot 2019-08-01 at 10 17 16 PM" src="https://user-images.githubusercontent.com/6406400/62346217-27ff6600-b4aa-11e9-8c72-326361673b9c.png">

With this change, it works as expected. No compiler errors! 🎉  

Thanks for the great library!