### PR TITLE
fix prompts/autocomplete

### DIFF
--- a/lib/prompts/autocomplete.js
+++ b/lib/prompts/autocomplete.js
@@ -8,7 +8,7 @@ const highlight = (input, color) => {
     let s = str.toLowerCase();
     let i = s.indexOf(val);
     let colored = color(str.slice(i, i + val.length));
-    return i > 0 ? str.slice(0, i) + colored + str.slice(i + val.length) : str;
+    return i >= 0 ? str.slice(0, i) + colored + str.slice(i + val.length) : str;
   };
 };
 

--- a/lib/prompts/autocomplete.js
+++ b/lib/prompts/autocomplete.js
@@ -8,7 +8,7 @@ const highlight = (input, color) => {
     let s = str.toLowerCase();
     let i = s.indexOf(val);
     let colored = color(str.slice(i, i + val.length));
-    return str.slice(0, i) + colored + str.slice(i + val.length);
+    return i > 0 ? str.slice(0, i) + colored + str.slice(i + val.length) : str;
   };
 };
 


### PR DESCRIPTION
If combined with fuzzy match library like [Fuse.js](https://fusejs.io/) as autocomplete `suggest` function, `highlight` duplicates `choice.message` strings unexpectedly.

![render1573310763577](https://user-images.githubusercontent.com/9415800/68530605-ffaac180-034c-11ea-800a-33f08dc47d11.gif)


<details>
<summary><strong>Minimal reproducible example</strong></summary>

``` javascript
const {AutoComplete} = require('enquirer');

const Fuse = require('fuse.js');

const choices = [
    'foobarbaz',
    'bar',
    'baz',
    'xxx',
].map(s => ({
    name: s,
    message: s,
    value: s,
}));

const fuse = new Fuse(choices, {keys: ['message']});


const p = new AutoComplete({
    name: 'highlight-bug',
    suggest: input => fuse.search(input),
    choices,
})

p.run()
    .then(console.log)
    .catch(console.error)
;
```

</details>

ref: https://github.com/Rich-Harris/degit/pull/109