### PR TITLE
Add Custom Highlight Support for AutoComplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,6 +477,82 @@ prompt.run()
 | `suggest`   | `function` | Greedy match, returns true if choice message contains input string. | Function that filters choices. Takes user input and a choices array, and returns a list of matching choices. |
 | `footer`   | `function` | None | Function that displays [footer text](https://github.com/enquirer/enquirer/blob/6c2819518a1e2ed284242a99a685655fbaabfa28/examples/autocomplete/option-footer.js#L10) |
 
+**Customizing suggest Function and Highlighting**
+
+When connecting `suggest` function to fuzzy search packages, you may want to highlight characters in the list with the match result provided by the package. Or maybe you want to create a highlighting algorithm yourself. Anyway you want to control which character to highlight. You can do that by setting the `highlightIndices` properties of choice objects in the array that `suggest` function are going to return. 
+
+You should set the `highlightIndices` property to an array consists of value pairs like `[starting_index, ending_index]`. For example, if the property is set to: 
+
+```js
+[[1,3],[5,9]]
+```
+
+The highlighted string will look like: e**xam**p**lestr**ing
+
+Note that the values should always be sorted in ascending order. 
+
+**Example Usage with Fuse.js**
+
+```js
+const { AutoComplete } = require('enquirer');
+const Fuse = require('fuse.js');
+
+const fuseOptions = {
+  shouldSort: true,
+  includeMatches: true,
+  tokenize: true,
+  threshold: 0.6,
+  location: 0,
+  distance: 100,
+  maxPatternLength: 32,
+  minMatchCharLength: 1,
+  keys: ['message']
+};
+
+const prompt = new AutoComplete({
+  name: 'flavor',
+  message: 'Pick your favorite flavor',
+  choices: [
+    'Almond',
+    'Apple',
+    'Banana',
+    'Blackberry',
+    'Blueberry',
+    'Cherry',
+    'Chocolate',
+    'Cinnamon',
+    'Coconut',
+    'Cranberry',
+    'Grape',
+    'Nougat',
+    'Orange',
+    'Pear',
+    'Pineapple',
+    'Raspberry',
+    'Strawberry',
+    'Vanilla',
+    'Watermelon',
+    'Wintergreen'
+  ],
+  suggest: (input,list) => {
+    if (input == '') return list;
+    let fuse = new Fuse(list, fuseOptions); 
+    return fuse.search(input)
+      .map(r => {
+        let r1 = r.item;
+        r1.highlightIndices = r.matches[0].indices;
+        //Fuse.js's indices property is an array of value pairs that meets the requirement for highlightIndices property here. 
+        //So we can assign the value to it directly. 
+        return r1;
+      });
+  }
+});
+
+prompt.run()
+  .then(answer => console.log('Answer:', answer))
+  .catch(console.error);
+```
+
 **Related prompts**
 
 * [Select](#select-prompt)

--- a/lib/prompts/autocomplete.js
+++ b/lib/prompts/autocomplete.js
@@ -4,7 +4,19 @@ const Select = require('./select');
 
 const highlight = (input, color) => {
   let val = input.toLowerCase();
-  return str => {
+  return (str, highlightIndices) => {
+    if (highlightIndices) {
+      return highlightIndices.flat().map((h, i) => (i % 2 === 0) ? h : h + 1).map((h, i, a) => {
+        switch (i) {
+          case 0:
+            return [str.slice(0, h), str.slice(h, a[1])];
+          case a.length - 1:
+            return str.slice(h);
+          default:
+            return str.slice(h, a[i + 1]);
+        }
+      }).flat().map((s, i) => (i % 2 === 0) ? s : color(s)).join('');
+    }
     let s = str.toLowerCase();
     let i = s.indexOf(val);
     let colored = color(str.slice(i, i + val.length));
@@ -54,7 +66,7 @@ class AutoComplete extends Select {
 
   async complete() {
     this.completing = true;
-    this.choices = await this.suggest(this.input, this.state._choices);
+    this.choices = await this.suggest(this.input, this.state._choices.map(ch => { ch.highlightIndices = undefined; return ch; }));
     this.state.limit = void 0; // allow getter/setter to reset limit
     this.index = Math.min(Math.max(this.visible.length - 1, 0), this.index);
     await this.render();
@@ -93,7 +105,7 @@ class AutoComplete extends Select {
 
     let color = highlight(this.input, style);
     let choices = this.choices;
-    this.choices = choices.map(ch => ({ ...ch, message: color(ch.message) }));
+    this.choices = choices.map(ch => ({ ...ch, message: color(ch.message, ch.highlightIndices) }));
     await super.render();
     this.choices = choices;
   }


### PR DESCRIPTION
When I was trying out the AutoComplete prompt I found the highlighting bug. I saw the pr that has fixed the bug but it's just disabling the feature when the highlighting function can't work properly. Also the package on npm doesn't seem to have patched it yet. So I went a step further to add custom highlighting support. 
The way I implement it involves adding a new property to the choice objects. I'm not sure if it's a good idea. And I just realized maybe I could achieve the same result without modifying autocomplete.js, by managing choice objects in suggest function. But it's working code and it doesn't seem to affect existing code, so I decided to create this pr. 
I also added description and sample code for this feature to readme. Please check it out for details. 