### PR TITLE
Fix TypeScript compiler error

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
+import { EventEmitter } from "events";
+
 interface BasePromptOptions {
   name: string | (() => string)
   type: string | (() => string)
@@ -89,7 +91,7 @@ type PromptOptions =
   | SortPromptOptions
   | BasePromptOptions
 
-declare class BasePrompt extends NodeJS.EventEmitter {
+declare class BasePrompt extends EventEmitter {
     constructor(options?: PromptOptions);
 
     render(): void;
@@ -97,7 +99,7 @@ declare class BasePrompt extends NodeJS.EventEmitter {
     run(): Promise<any>;
   }
 
-declare class Enquirer<T = object> extends NodeJS.EventEmitter {
+declare class Enquirer<T = object> extends EventEmitter {
   constructor(options?: object, answers?: T);
 
   /**


### PR DESCRIPTION
Extending the ambient interface results in an error:
TS2689: Cannot extend an interface 'NodeJS.EventEmitter'. Did you mean 'implements'?

By importing `EventEmitter` from `"events"`, the error goes away.