### PR TITLE
Export types from index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -82,7 +82,7 @@ interface SortPromptOptions extends BasePromptOptions {
   numbered?: boolean
 }
 
-type PromptOptions =
+export type PromptOptions =
   | ArrayPromptOptions
   | BooleanPromptOptions
   | StringPromptOptions
@@ -147,4 +147,11 @@ declare namespace Enquirer {
   class Prompt extends BasePrompt {}
 }
 
-export = Enquirer;
+export default Enquirer;
+
+export function prompt<T = object>(
+  questions:
+    | PromptOptions
+    | ((this: Enquirer) => PromptOptions)
+    | (PromptOptions | ((this: Enquirer) => PromptOptions))[]
+): Promise<T>;

--- a/test/types/test.ts
+++ b/test/types/test.ts
@@ -1,4 +1,4 @@
-import * as Enquirer from '../..';
+import Enquirer, { PromptOptions, prompt } from '../..';
 
 new Enquirer();
 new Enquirer.Prompt();
@@ -207,3 +207,8 @@ Enquirer.prompt({
   message: '',
   stdout: process.stdout
 });
+
+async function main() {
+  let question: PromptOptions = { name: 'test', type: 'text', message: '' };
+  let result = await prompt(question);
+}


### PR DESCRIPTION
This is a BREAKING CHANGE for TypeScript which allows export of types.

Where in TypeScript users would use, `import * as Enguirer from 'enguirer;`, they would now do:

`import Enguirer from 'enquirer';`

This PR adds exporting of the `PromptOptions` type so that developers can type check objects before passing them to `prompt(..)`

`  let question: PromptOptions = { name: 'test', type: 'text', message: '' };`

More individual types can be exported if this approach is approved, as it would be beneficial for TypeSrcript devs. 

This PR also exports the `prompt(..)` function to allow idiomatic import `import { prompt } from 'enquirer';` of prompt. 