### PR TITLE
Define `default` property

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,6 +14,7 @@ interface BasePromptOptions {
   onCancel?(name: string, value: any, prompt: Enquirer.Prompt): boolean | Promise<boolean>
   stdin?: NodeJS.ReadStream
   stdout?: NodeJS.WriteStream
+  default?: string | string[]
 }
 
 interface Choice {


### PR DESCRIPTION
I've used `string | string[]` because it doesn't cause a crash for types like `input` (vs types like `multiselect` which actually use the array values), and I'm hacking something together :)

It might be more accurate to later change this to be `string`, and then redefine it on the types that can use an array (such as Array).