### PR TITLE
fix: append number to input if exists, in array prompt

### DIFF
--- a/lib/prompts/autocomplete.js
+++ b/lib/prompts/autocomplete.js
@@ -52,6 +52,10 @@ class AutoComplete extends Select {
     return this.complete();
   }
 
+  number(ch) {
+    return this.append(ch);
+  }
+
   async complete() {
     this.completing = true;
     this.choices = await this.suggest(this.input, this.state._choices);

--- a/lib/types/array.js
+++ b/lib/types/array.js
@@ -267,8 +267,6 @@ class ArrayPrompt extends Prompt {
     this.num += n;
 
     let number = num => {
-      if (this.input) return this.append(num);
-
       let i = Number(num);
       if (i > this.choices.length - 1) return this.alert();
 

--- a/lib/types/array.js
+++ b/lib/types/array.js
@@ -267,6 +267,8 @@ class ArrayPrompt extends Prompt {
     this.num += n;
 
     let number = num => {
+      if (this.input) return this.append(num);
+
       let i = Number(num);
       if (i > this.choices.length - 1) return this.alert();
 

--- a/test/prompt.autocomplete.js
+++ b/test/prompt.autocomplete.js
@@ -21,17 +21,17 @@ describe('prompt-autocomplete', () => {
       prompt = new Prompt({
         message: 'Favorite flavor?',
         choices: [
-          { message: 'a', value: 'A' },
-          { message: 'b', value: 'BB' },
-          { message: 'c', value: 'CCC' },
-          { message: 'd', value: 'DDDD' }
+          { message: '2a', value: 'A' },
+          { message: '321b', value: 'BB' },
+          { message: '123c', value: 'CCC' },
+          { message: '1d', value: 'DDDD' }
         ]
       });
 
       prompt.once('run', async() => {
         await prompt.keypress(1);
-        await prompt.keypress(3);
         await prompt.keypress(2);
+        await prompt.keypress(3);
         await prompt.submit();
       });
 


### PR DESCRIPTION
Switches the behaviour of typing a number in the array-based prompts to appending it to the input normally, if one has already typed other text.

Should fix #237 and fix #199.  
~~Does not address #112 however.~~ Now fixes #112