### PR TITLE
Fix snippet types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -73,6 +73,7 @@ interface NumberPromptOptions extends BasePromptOptions {
 interface SnippetPromptOptions extends BasePromptOptions {
   type: 'snippet'
   newline?: string
+  template?: string
 }
 
 interface SortPromptOptions extends BasePromptOptions {
@@ -83,13 +84,13 @@ interface SortPromptOptions extends BasePromptOptions {
 }
 
 type PromptOptions =
+  | BasePromptOptions
   | ArrayPromptOptions
   | BooleanPromptOptions
   | StringPromptOptions
   | NumberPromptOptions
   | SnippetPromptOptions
   | SortPromptOptions
-  | BasePromptOptions
 
 declare class BasePrompt extends EventEmitter {
     constructor(options?: PromptOptions);


### PR DESCRIPTION
- was no mention of the template arg
- Basetype was overriding validate on snippet (line 87)