### PR TITLE
feat: expose Prompt instance

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,6 +105,7 @@ class Enquirer extends Events {
     assert(this.prompts[type], `Prompt "${type}" is not registered`);
 
     let prompt = new this.prompts[type](opts);
+    this._prompt = prompt;
     let value = get(this.answers, name);
 
     prompt.state.answers = this.answers;


### PR DESCRIPTION
Lets user use the Prompt instance for customization

Fixes #273

E.g.: 

```js
const enquirer = new Enquirer()
const promise = enquirer.prompt(...)

const result = await promise
// or 
enquirer._prompt.cancel()
```
