### PR TITLE
fix: Handle exception in `validate`

### DIFF
--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -125,9 +125,10 @@ class Prompt extends Events {
       result =
         this.state.error || (await this.validate(this.value, this.state));
     } catch (e) {
+      this.state.cancelled = true;
       await this.render();
       await this.close();
-      this.emit('cancel', e);
+      this.emit("cancel", e);
       return;
     }
 

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -35,11 +35,7 @@ class Prompt extends Events {
 
   async keypress(input, event = {}) {
     this.keypressed = true;
-    let key = keypress.action(
-      input,
-      keypress(input, event),
-      this.options.actions
-    );
+    let key = keypress.action(input, keypress(input, event), this.options.actions);
     this.state.keypress = key;
     this.emit('keypress', input, key);
     this.emit('state', this.state.clone());
@@ -89,7 +85,7 @@ class Prompt extends Events {
     let { prompt, after, rest } = this.sections();
     let { cursor, initial = '', input = '', value = '' } = this;
 
-    let size = (this.state.size = rest.length);
+    let size = this.state.size = rest.length;
     let state = { after, cursor, initial, input, prompt, size, value };
     let codes = ansi.cursor.restore(state);
     if (codes) {
@@ -184,9 +180,7 @@ class Prompt extends Events {
         this.write(ansi.cursor.down(sections.rest.length));
       }
       this.write('\n'.repeat(lines));
-    } catch (err) {
-      /* do nothing */
-    }
+    } catch (err) { /* do nothing */ }
 
     this.emit('close');
   }
@@ -227,7 +221,7 @@ class Prompt extends Events {
       let onSubmit = options.onSubmit.bind(this);
       let submit = this.submit.bind(this);
       delete this.options.onSubmit;
-      this.submit = async () => {
+      this.submit = async() => {
         await onSubmit(this.name, this.value, this);
         return submit();
       };
@@ -242,7 +236,7 @@ class Prompt extends Events {
   }
 
   run() {
-    return new Promise(async (resolve, reject) => {
+    return new Promise(async(resolve, reject) => {
       this.once('submit', resolve);
       this.once('cancel', reject);
       if (await this.skip()) {
@@ -270,12 +264,11 @@ class Prompt extends Events {
   }
 
   async prefix() {
-    let element = (await this.element('prefix')) || this.symbols;
+    let element = await this.element('prefix') || this.symbols;
     let timer = this.timers && this.timers.prefix;
     let state = this.state;
     state.timer = timer;
-    if (utils.isObject(element))
-      element = element[state.status] || element.pending;
+    if (utils.isObject(element)) element = element[state.status] || element.pending;
     if (!utils.hasColor(element)) {
       let style = this.styles[state.status] || this.styles.pending;
       return style(element);
@@ -292,7 +285,7 @@ class Prompt extends Events {
   }
 
   async separator() {
-    let element = (await this.element('separator')) || this.symbols;
+    let element = await this.element('separator') || this.symbols;
     let timer = this.timers && this.timers.separator;
     let state = this.state;
     state.timer = timer;
@@ -316,10 +309,7 @@ class Prompt extends Events {
       let styles = this.styles;
       let focused = this.index === i;
       let style = focused ? styles.primary : val => val;
-      let ele = await this.resolve(
-        val[focused ? 'on' : 'off'] || val,
-        this.state
-      );
+      let ele = await this.resolve(val[focused ? 'on' : 'off'] || val, this.state);
       let styled = !utils.hasColor(ele) ? style(ele) : ele;
       return focused ? styled : ' '.repeat(ele.length);
     }
@@ -367,7 +357,7 @@ class Prompt extends Events {
   }
 
   error(err) {
-    return !this.state.submitted ? err || this.state.error : '';
+    return !this.state.submitted ? (err || this.state.error) : '';
   }
 
   format(value) {
@@ -454,7 +444,7 @@ function setOptions(prompt) {
     'symbols',
     'theme',
     'timers',
-    'value',
+    'value'
   ];
 
   let ignoreFn = [
@@ -467,7 +457,7 @@ function setOptions(prompt) {
     'message',
     'prefix',
     'separator',
-    'skip',
+    'skip'
   ];
 
   for (let key of Object.keys(prompt.options)) {
@@ -489,7 +479,7 @@ function margin(value) {
     value = [value, value, value, value];
   }
   let arr = [].concat(value || []);
-  let pad = i => (i % 2 === 0 ? '\n' : ' ');
+  let pad = i => i % 2 === 0 ? '\n' : ' ';
   let res = [];
   for (let i = 0; i < 4; i++) {
     let char = pad(i);

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -122,8 +122,7 @@ class Prompt extends Events {
 
     let result;
     try {
-      result =
-        this.state.error || (await this.validate(this.value, this.state));
+      result = this.state.error || (await this.validate(this.value, this.state));
     } catch (e) {
       this.state.cancelled = true;
       await this.render();

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -1,13 +1,13 @@
-'use strict';
+"use strict";
 
-const Events = require('events');
-const colors = require('ansi-colors');
-const keypress = require('./keypress');
-const timer = require('./timer');
-const State = require('./state');
-const theme = require('./theme');
-const utils = require('./utils');
-const ansi = require('./ansi');
+const Events = require("events");
+const colors = require("ansi-colors");
+const keypress = require("./keypress");
+const timer = require("./timer");
+const State = require("./state");
+const theme = require("./theme");
+const utils = require("./utils");
+const ansi = require("./ansi");
 
 /**
  * Base class for creating a new Prompt.
@@ -23,7 +23,7 @@ class Prompt extends Events {
     theme(this);
     timer(this);
     this.state = new State(this);
-    this.initial = [options.initial, options.default].find(v => v != null);
+    this.initial = [options.initial, options.default].find((v) => v != null);
     this.stdout = options.stdout || process.stdout;
     this.stdin = options.stdin || process.stdin;
     this.scale = options.scale || 1;
@@ -35,12 +35,16 @@ class Prompt extends Events {
 
   async keypress(input, event = {}) {
     this.keypressed = true;
-    let key = keypress.action(input, keypress(input, event), this.options.actions);
+    let key = keypress.action(
+      input,
+      keypress(input, event),
+      this.options.actions
+    );
     this.state.keypress = key;
-    this.emit('keypress', input, key);
-    this.emit('state', this.state.clone());
+    this.emit("keypress", input, key);
+    this.emit("state", this.state.clone());
     let fn = this.options[key.action] || this[key.action] || this.dispatch;
-    if (typeof fn === 'function') {
+    if (typeof fn === "function") {
       return await fn.call(this, input, key);
     }
     this.alert();
@@ -49,7 +53,7 @@ class Prompt extends Events {
   alert() {
     delete this.state.alert;
     if (this.options.show === false) {
-      this.emit('alert');
+      this.emit("alert");
     } else {
       this.stdout.write(ansi.code.beep);
     }
@@ -74,7 +78,7 @@ class Prompt extends Events {
 
   clear(lines = 0) {
     let buffer = this.state.buffer;
-    this.state.buffer = '';
+    this.state.buffer = "";
     if ((!buffer && !lines) || this.options.show === false) return;
     this.stdout.write(ansi.cursor.down(lines) + ansi.clear(buffer, this.width));
   }
@@ -83,9 +87,9 @@ class Prompt extends Events {
     if (this.state.closed || this.options.show === false) return;
 
     let { prompt, after, rest } = this.sections();
-    let { cursor, initial = '', input = '', value = '' } = this;
+    let { cursor, initial = "", input = "", value = "" } = this;
 
-    let size = this.state.size = rest.length;
+    let size = (this.state.size = rest.length);
     let state = { after, cursor, initial, input, prompt, size, value };
     let codes = ansi.cursor.restore(state);
     if (codes) {
@@ -100,12 +104,12 @@ class Prompt extends Events {
     let idx = buf.indexOf(prompt);
     let header = buf.slice(0, idx);
     let rest = buf.slice(idx);
-    let lines = rest.split('\n');
+    let lines = rest.split("\n");
     let first = lines[0];
     let last = lines[lines.length - 1];
-    let promptLine = prompt + (input ? ' ' + input : '');
+    let promptLine = prompt + (input ? " " + input : "");
     let len = promptLine.length;
-    let after = len < first.length ? first.slice(len + 1) : '';
+    let after = len < first.length ? first.slice(len + 1) : "";
     return { header, prompt: first, after, rest: lines.slice(1), last };
   }
 
@@ -120,17 +124,27 @@ class Prompt extends Events {
       await this.options.onSubmit.call(this, this.name, this.value, this);
     }
 
-    let result = this.state.error || await this.validate(this.value, this.state);
-    if (result !== true) {
-      let error = '\n' + this.symbols.pointer + ' ';
+    let result;
+    try {
+      result =
+        this.state.error || (await this.validate(this.value, this.state));
+    } catch (e) {
+      await this.render();
+      await this.close();
+      this.emit("cancel", e);
+      return;
+    }
 
-      if (typeof result === 'string') {
+    if (result !== true) {
+      let error = "\n" + this.symbols.pointer + " ";
+
+      if (typeof result === "string") {
         error += result.trim();
       } else {
-        error += 'Invalid input';
+        error += "Invalid input";
       }
 
-      this.state.error = '\n' + this.styles.danger(error);
+      this.state.error = "\n" + this.styles.danger(error);
       this.state.submitted = false;
       await this.render();
       await this.alert();
@@ -144,7 +158,7 @@ class Prompt extends Events {
     await this.close();
 
     this.value = await this.result(this.value);
-    this.emit('submit', this.value);
+    this.emit("submit", this.value);
   }
 
   async cancel(err) {
@@ -153,11 +167,11 @@ class Prompt extends Events {
     await this.render();
     await this.close();
 
-    if (typeof this.options.onCancel === 'function') {
+    if (typeof this.options.onCancel === "function") {
       await this.options.onCancel.call(this, this.name, this.value, this);
     }
 
-    this.emit('cancel', await this.error(err));
+    this.emit("cancel", await this.error(err));
   }
 
   async close() {
@@ -169,22 +183,24 @@ class Prompt extends Events {
       if (sections.rest) {
         this.write(ansi.cursor.down(sections.rest.length));
       }
-      this.write('\n'.repeat(lines));
-    } catch (err) { /* do nothing */ }
+      this.write("\n".repeat(lines));
+    } catch (err) {
+      /* do nothing */
+    }
 
-    this.emit('close');
+    this.emit("close");
   }
 
   start() {
     if (!this.stop && this.options.show !== false) {
       this.stop = keypress.listen(this, this.keypress.bind(this));
-      this.once('close', this.stop);
+      this.once("close", this.stop);
     }
   }
 
   async skip() {
     this.skipped = this.options.skip === true;
-    if (typeof this.options.skip === 'function') {
+    if (typeof this.options.skip === "function") {
       this.skipped = await this.options.skip.call(this, this.name, this.value);
     }
     return this.skipped;
@@ -196,22 +212,22 @@ class Prompt extends Events {
     this.format = () => format.call(this, this.value);
     this.result = () => result.call(this, this.value);
 
-    if (typeof options.initial === 'function') {
+    if (typeof options.initial === "function") {
       this.initial = await options.initial.call(this, this);
     }
 
-    if (typeof options.onRun === 'function') {
+    if (typeof options.onRun === "function") {
       await options.onRun.call(this, this);
     }
 
     // if "options.onSubmit" is defined, we wrap the "submit" method to guarantee
     // that "onSubmit" will always called first thing inside the submit
     // method, regardless of how it's handled in inheriting prompts.
-    if (typeof options.onSubmit === 'function') {
+    if (typeof options.onSubmit === "function") {
       let onSubmit = options.onSubmit.bind(this);
       let submit = this.submit.bind(this);
       delete this.options.onSubmit;
-      this.submit = async() => {
+      this.submit = async () => {
         await onSubmit(this.name, this.value, this);
         return submit();
       };
@@ -222,19 +238,19 @@ class Prompt extends Events {
   }
 
   render() {
-    throw new Error('expected prompt to have a custom render method');
+    throw new Error("expected prompt to have a custom render method");
   }
 
   run() {
-    return new Promise(async(resolve, reject) => {
-      this.once('submit', resolve);
-      this.once('cancel', reject);
+    return new Promise(async (resolve, reject) => {
+      this.once("submit", resolve);
+      this.once("cancel", reject);
       if (await this.skip()) {
         this.render = () => {};
         return this.submit();
       }
       await this.initialize();
-      this.emit('run');
+      this.emit("run");
     });
   }
 
@@ -244,7 +260,7 @@ class Prompt extends Events {
     state.timer = timer;
     let value = options[name] || state[name] || symbols[name];
     let val = choice && choice[name] != null ? choice[name] : await value;
-    if (val === '') return val;
+    if (val === "") return val;
 
     let res = await this.resolve(val, state, choice, i);
     if (!res && choice && choice[name]) {
@@ -254,11 +270,12 @@ class Prompt extends Events {
   }
 
   async prefix() {
-    let element = await this.element('prefix') || this.symbols;
+    let element = (await this.element("prefix")) || this.symbols;
     let timer = this.timers && this.timers.prefix;
     let state = this.state;
     state.timer = timer;
-    if (utils.isObject(element)) element = element[state.status] || element.pending;
+    if (utils.isObject(element))
+      element = element[state.status] || element.pending;
     if (!utils.hasColor(element)) {
       let style = this.styles[state.status] || this.styles.pending;
       return style(element);
@@ -267,7 +284,7 @@ class Prompt extends Events {
   }
 
   async message() {
-    let message = await this.element('message');
+    let message = await this.element("message");
     if (!utils.hasColor(message)) {
       return this.styles.strong(message);
     }
@@ -275,7 +292,7 @@ class Prompt extends Events {
   }
 
   async separator() {
-    let element = await this.element('separator') || this.symbols;
+    let element = (await this.element("separator")) || this.symbols;
     let timer = this.timers && this.timers.separator;
     let state = this.state;
     state.timer = timer;
@@ -289,35 +306,38 @@ class Prompt extends Events {
   }
 
   async pointer(choice, i) {
-    let val = await this.element('pointer', choice, i);
+    let val = await this.element("pointer", choice, i);
 
-    if (typeof val === 'string' && utils.hasColor(val)) {
+    if (typeof val === "string" && utils.hasColor(val)) {
       return val;
     }
 
     if (val) {
       let styles = this.styles;
       let focused = this.index === i;
-      let style = focused ? styles.primary : val => val;
-      let ele = await this.resolve(val[focused ? 'on' : 'off'] || val, this.state);
+      let style = focused ? styles.primary : (val) => val;
+      let ele = await this.resolve(
+        val[focused ? "on" : "off"] || val,
+        this.state
+      );
       let styled = !utils.hasColor(ele) ? style(ele) : ele;
-      return focused ? styled : ' '.repeat(ele.length);
+      return focused ? styled : " ".repeat(ele.length);
     }
   }
 
   async indicator(choice, i) {
-    let val = await this.element('indicator', choice, i);
-    if (typeof val === 'string' && utils.hasColor(val)) {
+    let val = await this.element("indicator", choice, i);
+    if (typeof val === "string" && utils.hasColor(val)) {
       return val;
     }
     if (val) {
       let styles = this.styles;
       let enabled = choice.enabled === true;
       let style = enabled ? styles.success : styles.dark;
-      let ele = val[enabled ? 'on' : 'off'] || val;
+      let ele = val[enabled ? "on" : "off"] || val;
       return !utils.hasColor(ele) ? style(ele) : ele;
     }
-    return '';
+    return "";
   }
 
   body() {
@@ -325,20 +345,20 @@ class Prompt extends Events {
   }
 
   footer() {
-    if (this.state.status === 'pending') {
-      return this.element('footer');
+    if (this.state.status === "pending") {
+      return this.element("footer");
     }
   }
 
   header() {
-    if (this.state.status === 'pending') {
-      return this.element('header');
+    if (this.state.status === "pending") {
+      return this.element("header");
     }
   }
 
   async hint() {
-    if (this.state.status === 'pending' && !this.isValue(this.state.input)) {
-      let hint = await this.element('hint');
+    if (this.state.status === "pending" && !this.isValue(this.state.input)) {
+      let hint = await this.element("hint");
       if (!utils.hasColor(hint)) {
         return this.styles.muted(hint);
       }
@@ -347,7 +367,7 @@ class Prompt extends Events {
   }
 
   error(err) {
-    return !this.state.submitted ? (err || this.state.error) : '';
+    return !this.state.submitted ? err || this.state.error : "";
   }
 
   format(value) {
@@ -366,7 +386,7 @@ class Prompt extends Events {
   }
 
   isValue(value) {
-    return value != null && value !== '';
+    return value != null && value !== "";
   }
 
   resolve(value, ...args) {
@@ -415,68 +435,68 @@ class Prompt extends Events {
   }
 
   static get prompt() {
-    return options => new this(options).run();
+    return (options) => new this(options).run();
   }
 }
 
 function setOptions(prompt) {
-  let isValidKey = key => {
-    return prompt[key] === void 0 || typeof prompt[key] === 'function';
+  let isValidKey = (key) => {
+    return prompt[key] === void 0 || typeof prompt[key] === "function";
   };
 
   let ignore = [
-    'actions',
-    'choices',
-    'initial',
-    'margin',
-    'roles',
-    'styles',
-    'symbols',
-    'theme',
-    'timers',
-    'value'
+    "actions",
+    "choices",
+    "initial",
+    "margin",
+    "roles",
+    "styles",
+    "symbols",
+    "theme",
+    "timers",
+    "value",
   ];
 
   let ignoreFn = [
-    'body',
-    'footer',
-    'error',
-    'header',
-    'hint',
-    'indicator',
-    'message',
-    'prefix',
-    'separator',
-    'skip'
+    "body",
+    "footer",
+    "error",
+    "header",
+    "hint",
+    "indicator",
+    "message",
+    "prefix",
+    "separator",
+    "skip",
   ];
 
   for (let key of Object.keys(prompt.options)) {
     if (ignore.includes(key)) continue;
     if (/^on[A-Z]/.test(key)) continue;
     let option = prompt.options[key];
-    if (typeof option === 'function' && isValidKey(key)) {
+    if (typeof option === "function" && isValidKey(key)) {
       if (!ignoreFn.includes(key)) {
         prompt[key] = option.bind(prompt);
       }
-    } else if (typeof prompt[key] !== 'function') {
+    } else if (typeof prompt[key] !== "function") {
       prompt[key] = option;
     }
   }
 }
 
 function margin(value) {
-  if (typeof value === 'number') {
+  if (typeof value === "number") {
     value = [value, value, value, value];
   }
   let arr = [].concat(value || []);
-  let pad = i => i % 2 === 0 ? '\n' : ' ';
+  let pad = (i) => (i % 2 === 0 ? "\n" : " ");
   let res = [];
   for (let i = 0; i < 4; i++) {
     let char = pad(i);
     if (arr[i]) {
       res.push(char.repeat(arr[i]));
     } else {
-      res.push('');
+      res.push("");
     }
   }
   return res;

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -1,13 +1,13 @@
-"use strict";
+'use strict';
 
-const Events = require("events");
-const colors = require("ansi-colors");
-const keypress = require("./keypress");
-const timer = require("./timer");
-const State = require("./state");
-const theme = require("./theme");
-const utils = require("./utils");
-const ansi = require("./ansi");
+const Events = require('events');
+const colors = require('ansi-colors');
+const keypress = require('./keypress');
+const timer = require('./timer');
+const State = require('./state');
+const theme = require('./theme');
+const utils = require('./utils');
+const ansi = require('./ansi');
 
 /**
  * Base class for creating a new Prompt.
@@ -23,7 +23,7 @@ class Prompt extends Events {
     theme(this);
     timer(this);
     this.state = new State(this);
-    this.initial = [options.initial, options.default].find((v) => v != null);
+    this.initial = [options.initial, options.default].find(v => v != null);
     this.stdout = options.stdout || process.stdout;
     this.stdin = options.stdin || process.stdin;
     this.scale = options.scale || 1;
@@ -41,10 +41,10 @@ class Prompt extends Events {
       this.options.actions
     );
     this.state.keypress = key;
-    this.emit("keypress", input, key);
-    this.emit("state", this.state.clone());
+    this.emit('keypress', input, key);
+    this.emit('state', this.state.clone());
     let fn = this.options[key.action] || this[key.action] || this.dispatch;
-    if (typeof fn === "function") {
+    if (typeof fn === 'function') {
       return await fn.call(this, input, key);
     }
     this.alert();
@@ -53,7 +53,7 @@ class Prompt extends Events {
   alert() {
     delete this.state.alert;
     if (this.options.show === false) {
-      this.emit("alert");
+      this.emit('alert');
     } else {
       this.stdout.write(ansi.code.beep);
     }
@@ -78,7 +78,7 @@ class Prompt extends Events {
 
   clear(lines = 0) {
     let buffer = this.state.buffer;
-    this.state.buffer = "";
+    this.state.buffer = '';
     if ((!buffer && !lines) || this.options.show === false) return;
     this.stdout.write(ansi.cursor.down(lines) + ansi.clear(buffer, this.width));
   }
@@ -87,7 +87,7 @@ class Prompt extends Events {
     if (this.state.closed || this.options.show === false) return;
 
     let { prompt, after, rest } = this.sections();
-    let { cursor, initial = "", input = "", value = "" } = this;
+    let { cursor, initial = '', input = '', value = '' } = this;
 
     let size = (this.state.size = rest.length);
     let state = { after, cursor, initial, input, prompt, size, value };
@@ -104,12 +104,12 @@ class Prompt extends Events {
     let idx = buf.indexOf(prompt);
     let header = buf.slice(0, idx);
     let rest = buf.slice(idx);
-    let lines = rest.split("\n");
+    let lines = rest.split('\n');
     let first = lines[0];
     let last = lines[lines.length - 1];
-    let promptLine = prompt + (input ? " " + input : "");
+    let promptLine = prompt + (input ? ' ' + input : '');
     let len = promptLine.length;
-    let after = len < first.length ? first.slice(len + 1) : "";
+    let after = len < first.length ? first.slice(len + 1) : '';
     return { header, prompt: first, after, rest: lines.slice(1), last };
   }
 
@@ -131,20 +131,20 @@ class Prompt extends Events {
     } catch (e) {
       await this.render();
       await this.close();
-      this.emit("cancel", e);
+      this.emit('cancel', e);
       return;
     }
 
     if (result !== true) {
-      let error = "\n" + this.symbols.pointer + " ";
+      let error = '\n' + this.symbols.pointer + ' ';
 
-      if (typeof result === "string") {
+      if (typeof result === 'string') {
         error += result.trim();
       } else {
-        error += "Invalid input";
+        error += 'Invalid input';
       }
 
-      this.state.error = "\n" + this.styles.danger(error);
+      this.state.error = '\n' + this.styles.danger(error);
       this.state.submitted = false;
       await this.render();
       await this.alert();
@@ -158,7 +158,7 @@ class Prompt extends Events {
     await this.close();
 
     this.value = await this.result(this.value);
-    this.emit("submit", this.value);
+    this.emit('submit', this.value);
   }
 
   async cancel(err) {
@@ -167,11 +167,11 @@ class Prompt extends Events {
     await this.render();
     await this.close();
 
-    if (typeof this.options.onCancel === "function") {
+    if (typeof this.options.onCancel === 'function') {
       await this.options.onCancel.call(this, this.name, this.value, this);
     }
 
-    this.emit("cancel", await this.error(err));
+    this.emit('cancel', await this.error(err));
   }
 
   async close() {
@@ -183,24 +183,24 @@ class Prompt extends Events {
       if (sections.rest) {
         this.write(ansi.cursor.down(sections.rest.length));
       }
-      this.write("\n".repeat(lines));
+      this.write('\n'.repeat(lines));
     } catch (err) {
       /* do nothing */
     }
 
-    this.emit("close");
+    this.emit('close');
   }
 
   start() {
     if (!this.stop && this.options.show !== false) {
       this.stop = keypress.listen(this, this.keypress.bind(this));
-      this.once("close", this.stop);
+      this.once('close', this.stop);
     }
   }
 
   async skip() {
     this.skipped = this.options.skip === true;
-    if (typeof this.options.skip === "function") {
+    if (typeof this.options.skip === 'function') {
       this.skipped = await this.options.skip.call(this, this.name, this.value);
     }
     return this.skipped;
@@ -212,18 +212,18 @@ class Prompt extends Events {
     this.format = () => format.call(this, this.value);
     this.result = () => result.call(this, this.value);
 
-    if (typeof options.initial === "function") {
+    if (typeof options.initial === 'function') {
       this.initial = await options.initial.call(this, this);
     }
 
-    if (typeof options.onRun === "function") {
+    if (typeof options.onRun === 'function') {
       await options.onRun.call(this, this);
     }
 
     // if "options.onSubmit" is defined, we wrap the "submit" method to guarantee
     // that "onSubmit" will always called first thing inside the submit
     // method, regardless of how it's handled in inheriting prompts.
-    if (typeof options.onSubmit === "function") {
+    if (typeof options.onSubmit === 'function') {
       let onSubmit = options.onSubmit.bind(this);
       let submit = this.submit.bind(this);
       delete this.options.onSubmit;
@@ -238,19 +238,19 @@ class Prompt extends Events {
   }
 
   render() {
-    throw new Error("expected prompt to have a custom render method");
+    throw new Error('expected prompt to have a custom render method');
   }
 
   run() {
     return new Promise(async (resolve, reject) => {
-      this.once("submit", resolve);
-      this.once("cancel", reject);
+      this.once('submit', resolve);
+      this.once('cancel', reject);
       if (await this.skip()) {
         this.render = () => {};
         return this.submit();
       }
       await this.initialize();
-      this.emit("run");
+      this.emit('run');
     });
   }
 
@@ -260,7 +260,7 @@ class Prompt extends Events {
     state.timer = timer;
     let value = options[name] || state[name] || symbols[name];
     let val = choice && choice[name] != null ? choice[name] : await value;
-    if (val === "") return val;
+    if (val === '') return val;
 
     let res = await this.resolve(val, state, choice, i);
     if (!res && choice && choice[name]) {
@@ -270,7 +270,7 @@ class Prompt extends Events {
   }
 
   async prefix() {
-    let element = (await this.element("prefix")) || this.symbols;
+    let element = (await this.element('prefix')) || this.symbols;
     let timer = this.timers && this.timers.prefix;
     let state = this.state;
     state.timer = timer;
@@ -284,7 +284,7 @@ class Prompt extends Events {
   }
 
   async message() {
-    let message = await this.element("message");
+    let message = await this.element('message');
     if (!utils.hasColor(message)) {
       return this.styles.strong(message);
     }
@@ -292,7 +292,7 @@ class Prompt extends Events {
   }
 
   async separator() {
-    let element = (await this.element("separator")) || this.symbols;
+    let element = (await this.element('separator')) || this.symbols;
     let timer = this.timers && this.timers.separator;
     let state = this.state;
     state.timer = timer;
@@ -306,38 +306,38 @@ class Prompt extends Events {
   }
 
   async pointer(choice, i) {
-    let val = await this.element("pointer", choice, i);
+    let val = await this.element('pointer', choice, i);
 
-    if (typeof val === "string" && utils.hasColor(val)) {
+    if (typeof val === 'string' && utils.hasColor(val)) {
       return val;
     }
 
     if (val) {
       let styles = this.styles;
       let focused = this.index === i;
-      let style = focused ? styles.primary : (val) => val;
+      let style = focused ? styles.primary : val => val;
       let ele = await this.resolve(
-        val[focused ? "on" : "off"] || val,
+        val[focused ? 'on' : 'off'] || val,
         this.state
       );
       let styled = !utils.hasColor(ele) ? style(ele) : ele;
-      return focused ? styled : " ".repeat(ele.length);
+      return focused ? styled : ' '.repeat(ele.length);
     }
   }
 
   async indicator(choice, i) {
-    let val = await this.element("indicator", choice, i);
-    if (typeof val === "string" && utils.hasColor(val)) {
+    let val = await this.element('indicator', choice, i);
+    if (typeof val === 'string' && utils.hasColor(val)) {
       return val;
     }
     if (val) {
       let styles = this.styles;
       let enabled = choice.enabled === true;
       let style = enabled ? styles.success : styles.dark;
-      let ele = val[enabled ? "on" : "off"] || val;
+      let ele = val[enabled ? 'on' : 'off'] || val;
       return !utils.hasColor(ele) ? style(ele) : ele;
     }
-    return "";
+    return '';
   }
 
   body() {
@@ -345,20 +345,20 @@ class Prompt extends Events {
   }
 
   footer() {
-    if (this.state.status === "pending") {
-      return this.element("footer");
+    if (this.state.status === 'pending') {
+      return this.element('footer');
     }
   }
 
   header() {
-    if (this.state.status === "pending") {
-      return this.element("header");
+    if (this.state.status === 'pending') {
+      return this.element('header');
     }
   }
 
   async hint() {
-    if (this.state.status === "pending" && !this.isValue(this.state.input)) {
-      let hint = await this.element("hint");
+    if (this.state.status === 'pending' && !this.isValue(this.state.input)) {
+      let hint = await this.element('hint');
       if (!utils.hasColor(hint)) {
         return this.styles.muted(hint);
       }
@@ -367,7 +367,7 @@ class Prompt extends Events {
   }
 
   error(err) {
-    return !this.state.submitted ? err || this.state.error : "";
+    return !this.state.submitted ? err || this.state.error : '';
   }
 
   format(value) {
@@ -386,7 +386,7 @@ class Prompt extends Events {
   }
 
   isValue(value) {
-    return value != null && value !== "";
+    return value != null && value !== '';
   }
 
   resolve(value, ...args) {
@@ -435,68 +435,68 @@ class Prompt extends Events {
   }
 
   static get prompt() {
-    return (options) => new this(options).run();
+    return options => new this(options).run();
   }
 }
 
 function setOptions(prompt) {
-  let isValidKey = (key) => {
-    return prompt[key] === void 0 || typeof prompt[key] === "function";
+  let isValidKey = key => {
+    return prompt[key] === void 0 || typeof prompt[key] === 'function';
   };
 
   let ignore = [
-    "actions",
-    "choices",
-    "initial",
-    "margin",
-    "roles",
-    "styles",
-    "symbols",
-    "theme",
-    "timers",
-    "value",
+    'actions',
+    'choices',
+    'initial',
+    'margin',
+    'roles',
+    'styles',
+    'symbols',
+    'theme',
+    'timers',
+    'value',
   ];
 
   let ignoreFn = [
-    "body",
-    "footer",
-    "error",
-    "header",
-    "hint",
-    "indicator",
-    "message",
-    "prefix",
-    "separator",
-    "skip",
+    'body',
+    'footer',
+    'error',
+    'header',
+    'hint',
+    'indicator',
+    'message',
+    'prefix',
+    'separator',
+    'skip',
   ];
 
   for (let key of Object.keys(prompt.options)) {
     if (ignore.includes(key)) continue;
     if (/^on[A-Z]/.test(key)) continue;
     let option = prompt.options[key];
-    if (typeof option === "function" && isValidKey(key)) {
+    if (typeof option === 'function' && isValidKey(key)) {
       if (!ignoreFn.includes(key)) {
         prompt[key] = option.bind(prompt);
       }
-    } else if (typeof prompt[key] !== "function") {
+    } else if (typeof prompt[key] !== 'function') {
       prompt[key] = option;
     }
   }
 }
 
 function margin(value) {
-  if (typeof value === "number") {
+  if (typeof value === 'number') {
     value = [value, value, value, value];
   }
   let arr = [].concat(value || []);
-  let pad = (i) => (i % 2 === 0 ? "\n" : " ");
+  let pad = i => (i % 2 === 0 ? '\n' : ' ');
   let res = [];
   for (let i = 0; i < 4; i++) {
     let char = pad(i);
     if (arr[i]) {
       res.push(char.repeat(arr[i]));
     } else {
-      res.push("");
+      res.push('');
     }
   }
   return res;


### PR DESCRIPTION
Closes https://github.com/enquirer/enquirer/issues/277

Instead of causing unhandled promise rejections, exceptions in `validate` should cause the prompt to end and the exception bubble up.

Now exceptions are caught:
```
✔ What is your username? · John Doe
An error occurred and the program ended :(
```

Instead of being unhandled:
```
? What is your username? › John Doe (node:9358) UnhandledPromiseRejectionWarning: Error: boo!
    at Input.validate (/Users/sqren/srv/enquirer-demo/index.js:8:11)
    at Input.submit (/Users/sqren/srv/enquirer-demo/node_modules/enquirer/lib/prompt.js:123:49)
    at Input.submit (/Users/sqren/srv/enquirer-demo/node_modules/enquirer/lib/prompts/input.js:51:18)
    at Input.keypress (/Users/sqren/srv/enquirer-demo/node_modules/enquirer/lib/prompt.js:44:23)
    at Input.keypress (/Users/sqren/srv/enquirer-demo/node_modules/enquirer/lib/types/string.js:24:18)
    at ReadStream.on (/Users/sqren/srv/enquirer-demo/node_modules/enquirer/lib/keypress.js:205:26)
    at ReadStream.emit (events.js:203:15)
    at emitKeys (internal/readline.js:424:14)
    at emitKeys.next (<anonymous>)
    at ReadStream.onData (readline.js:1073:36)
(node:9358) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
(node:9358) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```