### PR TITLE
Add missing types for prompt

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -83,7 +83,7 @@ interface SortPromptOptions extends BasePromptOptions {
   numbered?: boolean
 }
 
-type PromptOptions =
+export type PromptOptions =
   | BasePromptOptions
   | ArrayPromptOptions
   | BooleanPromptOptions
@@ -98,6 +98,18 @@ declare class BasePrompt extends EventEmitter {
     render(): void;
 
     run(): Promise<any>;
+  
+    cursorHide: () => void;
+    state: {
+      size: number;
+      submitted: boolean;
+    };
+    keypress: (char: string | null, evt: { name: string }) => void;
+    clear: (val: number) => void;
+    write: (val: string) => void;
+    restore: () => void;
+    prefix: () => string;
+    submit: () => void;    
   }
 
 declare class Enquirer<T = object> extends EventEmitter {


### PR DESCRIPTION
This PR exports `PromptOptions` so it can be consumed, and adds a few properties to `BasePrompt`

This is much less ambitious than https://github.com/enquirer/enquirer/pull/261 but might be easier to merge since the scope is much smaller.