### PR TITLE
Add `prefix` property to the `BasePromptOptions` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,7 @@ interface BasePromptOptions {
   name: string | (() => string)
   type: string | (() => string)
   message: string | (() => string) | (() => Promise<string>)
+  prefix?: string
   initial?: any
   required?: boolean
   format?(value: string): string | Promise<string>


### PR DESCRIPTION
Seems like this is allowed - we use it in Changesets for example [here](https://github.com/atlassian/changesets/blob/0f0b6ad10744de9a8a32305796bd78d33bb1a426/packages/cli/src/utils/cli-utilities.ts#L35) and it works.