### PR TITLE
Upgrade ansi-colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "cover": "nyc --reporter=text --reporter=html mocha"
   },
   "dependencies": {
-    "ansi-colors": "^3.2.1"
+    "ansi-colors": "^4.1.1"
   },
   "devDependencies": {
     "@types/node": "^8",


### PR DESCRIPTION
Enquirer uses old version. Also congrats on eslint adoption.

Here are changes in v3 -> v4

https://github.com/doowb/ansi-colors/commit/0f15d780100e07213182f856efbf0e58fe57f49c
https://github.com/doowb/ansi-colors/commit/e66ed2faab2461f3f4a7ac161a81a9b1f4b926b1