### PR TITLE
re-ordered the keys in combos.js to be more logical, coherent and alphabetical

### DIFF
--- a/lib/combos.js
+++ b/lib/combos.js
@@ -20,7 +20,7 @@ exports.ctrl = {
   m: 'cancel',
   n: 'newItem',
   p: 'search',
-  r: 'remove',
+  r: 'deleteItem',
   s: 'save',
   u: 'undo',
   v: 'paste',

--- a/lib/combos.js
+++ b/lib/combos.js
@@ -14,18 +14,18 @@ exports.ctrl = {
   f: 'forward',
   g: 'reset',
   i: 'tab',
+  j: 'submit',
   k: 'cutForward',
   l: 'reset',
-  n: 'newItem',
   m: 'cancel',
-  j: 'submit',
+  n: 'newItem',
   p: 'search',
   r: 'remove',
   s: 'save',
   u: 'undo',
+  v: 'paste',
   w: 'cutLeft',
-  x: 'toggleCursor',
-  v: 'paste'
+  x: 'toggleCursor'
 };
 
 exports.shift = {
@@ -47,8 +47,8 @@ exports.fn = {
 // <alt> on Windows
 exports.option = {
   b: 'backward',
-  f: 'forward',
   d: 'cutRight',
+  f: 'forward',
   left: 'cutLeft',
   up: 'altUp',
   down: 'altDown'
@@ -60,16 +60,16 @@ exports.keys = {
   home: 'home', // <fn>+<left> (mac), <home> (windows)
   end: 'end', // <fn>+<right> (mac), <end> (windows)
   cancel: 'cancel',
+  escape: 'cancel',
   delete: 'deleteForward',
   backspace: 'delete',
+  left: 'left',
+  right: 'right',
+  up: 'up',
   down: 'down',
   enter: 'submit',
-  escape: 'cancel',
-  left: 'left',
+  return: 'submit',
   space: 'space',
   number: 'number',
-  return: 'submit',
-  right: 'right',
-  tab: 'next',
-  up: 'up'
+  tab: 'next'
 };

--- a/lib/types/array.js
+++ b/lib/types/array.js
@@ -175,6 +175,19 @@ class ArrayPrompt extends Prompt {
     return this.render();
   }
 
+  // delete focused item
+  // can set required = true in choices option (when creating the prompt) to disallow deletion of items
+  async deleteItem() {
+    if (this.focused.required !== true) {
+      let focusedIndex = this.choices.indexOf(this.focused)
+      this.choices.splice(focusedIndex, 1)
+      this.index = this.choices.length - 1;
+      this.limit = this.choices.length;
+  
+      return this.render()
+    }
+  }
+
   indent(choice) {
     if (choice.indent == null) {
       return choice.level > 1 ? '  '.repeat(choice.level - 1) : '';

--- a/test/utils.actions.js
+++ b/test/utils.actions.js
@@ -27,7 +27,7 @@ describe('utils.actions', function() {
     assert.equal(act({ name: 'd', ctrl: true }), 'deleteForward');
     assert.equal(act({ name: 'e', ctrl: true }), 'last');
     assert.equal(act({ name: 'g', ctrl: true }), 'reset');
-    assert.equal(act({ name: 'r', ctrl: true }), 'remove');
+    assert.equal(act({ name: 'r', ctrl: true }), 'deleteItem');
     assert.equal(act({ name: 's', ctrl: true }), 'save');
     assert.equal(act({ name: 'u', ctrl: true }), 'undo');
   });


### PR DESCRIPTION
Currently, the ctrl group is not alphabetically sorted, and the keys group was not ordered very logically. 
This pull request tries to addresses this. 

In the option group, I opted to re-order this so it is sorted alphabetically, however this resulted in the following - 

`  b: 'backward',
  d: 'cutRight',
  f: 'forward',`

which was changed from -

`  b: 'backward',
  f: 'forward',
  d: 'cutRight',`

I believe that alphabetically ordered is more consistent with the other groups (ctrl), but this may be something you wish to retain rather than adjust. Hope this helps. 