### PR TITLE
Fix .validate promise return type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,7 @@ interface BasePromptOptions {
   format?(value: string): string | Promise<string>
   result?(value: string): string | Promise<string>
   skip?: ((state: object) => boolean | Promise<boolean>) | boolean
-  validate?(value: string): boolean | Promise<boolean> | string | Promise<string>
+  validate?(value: string): boolean | string | Promise<boolean | string>
   onSubmit?(name: string, value: any, prompt: Enquirer.Prompt): boolean | Promise<boolean>
   onCancel?(name: string, value: any, prompt: Enquirer.Prompt): boolean | Promise<boolean>
   stdin?: NodeJS.ReadStream


### PR DESCRIPTION
When using .validate with promises/async, the return type needs to allow the function to return boolean or string, rather than just boolean or just string. Otherwise, the string option isn't useful (since you can return a string as an error, but can't return true to indicate a valid prompt).

Thanks for a great library!