### PR TITLE
Remove dependency on nodejs readline module

### DIFF
--- a/lib/keypress.js
+++ b/lib/keypress.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const emitKeypressEvents = require('keypress')
+const emitKeypressEvents = require('keypress');
 const combos = require('./combos');
 
 /* eslint-disable no-control-regex */
@@ -198,7 +198,7 @@ keypress.listen = (options = {}, onKeypress) => {
   if (!stdin || (stdin !== process.stdin && !stdin.isTTY)) {
     throw new Error('Invalid stream passed');
   }
-  emitKeypressEvents(stdin)
+  emitKeypressEvents(stdin);
 
   let on = (buf, key) => onKeypress(buf, keypress(buf, key));
   let isRaw = stdin.isRaw;
@@ -210,8 +210,8 @@ keypress.listen = (options = {}, onKeypress) => {
   let off = () => {
     if (stdin.isTTY) stdin.setRawMode(isRaw);
     stdin.removeListener('keypress', on);
-    stdin.pause()
-    stdin.emit('close')    
+    stdin.pause();
+    stdin.emit('close');
   };
 
   return off;

--- a/lib/keypress.js
+++ b/lib/keypress.js
@@ -210,6 +210,8 @@ keypress.listen = (options = {}, onKeypress) => {
   let off = () => {
     if (stdin.isTTY) stdin.setRawMode(isRaw);
     stdin.removeListener('keypress', on);
+    stdin.pause()
+    stdin.emit('close')    
   };
 
   return off;

--- a/lib/keypress.js
+++ b/lib/keypress.js
@@ -210,7 +210,6 @@ keypress.listen = (options = {}, onKeypress) => {
   let off = () => {
     if (stdin.isTTY) stdin.setRawMode(isRaw);
     stdin.removeListener('keypress', on);
-    stdin.pause();
     stdin.emit('close');
   };
 

--- a/lib/keypress.js
+++ b/lib/keypress.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const readline = require('readline');
+const emitKeypressEvents = require('keypress')
 const combos = require('./combos');
 
 /* eslint-disable no-control-regex */
@@ -198,22 +198,18 @@ keypress.listen = (options = {}, onKeypress) => {
   if (!stdin || (stdin !== process.stdin && !stdin.isTTY)) {
     throw new Error('Invalid stream passed');
   }
+  emitKeypressEvents(stdin)
 
-  let rl = readline.createInterface({ terminal: true, input: stdin });
-  readline.emitKeypressEvents(stdin, rl);
-
-  let on = (buf, key) => onKeypress(buf, keypress(buf, key), rl);
+  let on = (buf, key) => onKeypress(buf, keypress(buf, key));
   let isRaw = stdin.isRaw;
 
   if (stdin.isTTY) stdin.setRawMode(true);
   stdin.on('keypress', on);
-  rl.resume();
+  stdin.resume();
 
   let off = () => {
     if (stdin.isTTY) stdin.setRawMode(isRaw);
     stdin.removeListener('keypress', on);
-    rl.pause();
-    rl.close();
   };
 
   return off;

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "cover": "nyc --reporter=text --reporter=html mocha"
   },
   "dependencies": {
-    "ansi-colors": "^4.1.1"
+    "ansi-colors": "^4.1.1",
+    "keypress": "^0.2.1"
   },
   "devDependencies": {
     "@types/node": "^8",


### PR DESCRIPTION
The [nodejs readline module](https://nodejs.org/api/readline.html) has no equivalent in the browser as per https://github.com/azu/node-browser-polyfill-gap

Removing this dependency makes enquirer able to be used in the browser.

Readline appears to be a bit of a hack module, and appears to only be used in enquirer to start the emitting of 'keypress' events.