### PR TITLE
Fix a typo in TypeScript types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -36,7 +36,7 @@ interface ArrayPromptOptions extends BasePromptOptions {
     | 'scale'
   choices: string[] | Choice[]
   maxChoices?: number
-  muliple?: boolean
+  multiple?: boolean
   initial?: number
   delay?: number
   separator?: boolean


### PR DESCRIPTION
There seems to be a small typo in `ArrayPromptOptions` interface declaration here at:
[index.d.ts#L39](https://github.com/enquirer/enquirer/blob/8d626c206733420637660ac7c2098d7de45e8590/index.d.ts#L39
)

#318 