### PR TITLE
fix(Enquirer): export EnquirerOptions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -146,6 +146,7 @@ declare namespace Enquirer {
   ): Promise<T>;
 
   class Prompt extends BasePrompt {}
+  type EnquirerOptions = PromptOptions
 }
 
 export = Enquirer;


### PR DESCRIPTION
 Add and export EnquirerOptions for better autocomplete & use its types on partial parts on the code such as 
```ts
import { prompt, EnquirerOptions } from "enquirer";
...
const Inputs: EnquirerOptions[] = [
    {
      type: "input",
      name: "in",
      initial: 1,
      message: "Set input number (default 1):",
    },
];
Inputs.push({
    type: "confirm",
    initial: true,
    name: "save",
    message:"Are you sure ? (default YES):",
})
...
```