### PR TITLE
Format Confirm as "yes/no"

### DIFF
--- a/examples/confirm/format-yes-no.js
+++ b/examples/confirm/format-yes-no.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const { Confirm } = require('enquirer');
+
+const prompt = new Confirm({
+  name: 'toast',
+  message: 'Do you like toast?',
+  initial: true,
+  format() {
+    return /^[ty1]/i.test(prompt.input) ? 'yes' : 'no';
+  }
+});
+
+prompt.run()
+  .then(answer => console.log('Answer:', answer))
+  .catch(console.error);


### PR DESCRIPTION
- Adding a Confirm example showing  "yes/no" as format instead of the default "true/false".

Hopefully, this helps showcase how you can create a "yes/no" question versus a "true/false" confirm statement.