### PR TITLE
fix: pressing 'g' correctly toggles nested groups

### DIFF
--- a/lib/types/array.js
+++ b/lib/types/array.js
@@ -220,9 +220,10 @@ class ArrayPrompt extends Prompt {
     return this.render();
   }
 
-  g(choice = this.focused) {
+  g() {
     if (!this.choices.some(ch => !!ch.parent)) return this.a();
-    this.toggle((choice.parent && !choice.choices) ? choice.parent : choice);
+    const focused = this.focused;
+    this.toggle((focused.parent && !focused.choices) ? focused.parent : focused);
     return this.render();
   }
 

--- a/test/prompt.multiselect.js
+++ b/test/prompt.multiselect.js
@@ -385,5 +385,43 @@ describe('multiselect', function() {
 
       return prompt.run().then(expect(['c']));
     });
+
+    it(`should handle selecting groups with <g> (within group)`, () => {
+      prompt = new Prompt({
+        message: 'prompt-multiselect',
+        choices: [
+          { name: 'a', role:'heading', choices: ['a1','a2']},
+          { name: 'b', role:'heading', choices: ['b1','b2']}
+        ]
+      });
+
+      prompt.on('run', async() => {
+        await prompt.keypress(null, down);
+        await prompt.keypress('g');
+        await prompt.submit();
+      });
+
+      return prompt.run().then(expect(['a1','a2']));
+    });
+
+    it(`should handle selecting groups with <g> (on parent)`, () => {
+      prompt = new Prompt({
+        message: 'prompt-multiselect',
+        choices: [
+          { name: 'a', choices: ['a1','a2']},
+          { name: 'b', choices: ['b1','b2']}
+        ]
+      });
+
+      prompt.on('run', async() => {
+        await prompt.keypress(null, down);
+        await prompt.keypress(null, down);
+        await prompt.keypress(null, down);
+        await prompt.keypress('g');
+        await prompt.submit();
+      });
+
+      return prompt.run().then(expect(['b','b1','b2']));
+    });
   });
 });


### PR DESCRIPTION
the `g` function was passed the current key (the string "g"), which overrided the choice param, and caused an error:

`TypeError: Cannot create property 'enabled' on string 'g'`

I've also included supporting tests.