### PR TITLE
add onExit cleanup

### DIFF
--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -57,7 +57,11 @@ class Prompt extends Events {
 
   cursorHide() {
     this.stdout.write(ansi.cursor.hide());
-    utils.onExit(() => this.cursorShow());
+    const releaseOnExit = utils.onExit(() => this.cursorShow());
+    this.on('close', () => {
+      this.cursorShow();
+      releaseOnExit();
+    });
   }
 
   cursorShow() {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,8 +2,8 @@
 
 const toString = Object.prototype.toString;
 const colors = require('ansi-colors');
-let called = false;
-let fns = [];
+let onExitCalled = false;
+let onExitCallbacks = new Set();
 
 const complements = {
   'yellow': 'blue',
@@ -228,25 +228,36 @@ exports.mixinEmitter = (obj, emitter) => {
   }
 };
 
+const onExit = (quit, code) => {
+  if (onExitCalled) return;
+
+  onExitCalled = true;
+  onExitCallbacks.forEach(fn => fn());
+
+  if (quit === true) {
+    process.exit(128 + code);
+  }
+};
+const onSigTerm = onExit.bind(null, true, 15);
+const onSigInt = onExit.bind(null, true, 2);
+
 exports.onExit = callback => {
-  const onExit = (quit, code) => {
-    if (called) return;
-
-    called = true;
-    fns.forEach(fn => fn());
-
-    if (quit === true) {
-      process.exit(128 + code);
-    }
-  };
-
-  if (fns.length === 0) {
-    process.once('SIGTERM', onExit.bind(null, true, 15));
-    process.once('SIGINT', onExit.bind(null, true, 2));
+  if (onExitCallbacks.size === 0) {
+    process.once('SIGTERM', onSigTerm);
+    process.once('SIGINT', onSigInt);
     process.once('exit', onExit);
   }
 
-  fns.push(callback);
+  onExitCallbacks.add(callback);
+
+  return () => {
+    onExitCallbacks.delete(callback);
+    if (onExitCallbacks.size === 0) {
+      process.off('SIGTERM', onSigTerm);
+      process.off('SIGINT', onSigInt);
+      process.off('exit', onExit);
+    }
+  }
 };
 
 exports.define = (obj, key, value) => {


### PR DESCRIPTION
Closes #372 

- rework utils.onExit to return a release function that cleans up process event listeners
- cursorHide call cursorShow on 'close'
- cursorHide release it's onExit callback on 'close'