### PR TITLE
Docs(README): Remove $ from shell commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,12 +86,12 @@ Get started with Enquirer, the most powerful and easy-to-use Node.js library for
 Install with [npm](https://www.npmjs.com/):
 
 ```sh
-$ npm install enquirer --save
+npm install enquirer --save
 ```
 Install with [yarn](https://yarnpkg.com/en/):
 
 ```sh
-$ yarn add enquirer
+yarn add enquirer
 ```
 
 <p align="center">


### PR DESCRIPTION
First of all, thanks for this amazing library.

This is a small contribution to make it easier to copy, paste and execute shell commands from the README file.

Today all shell commands are being copied with a $ sign at the beginning, causing `command not found: $ error when executed (see below).

![enquirer-shell-commands](https://user-images.githubusercontent.com/6290749/140305882-de30ed4b-9686-4fab-a91d-2699093faa6a.gif)

