### PR TITLE
Remove non-customizable validating style

### DIFF
--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -122,7 +122,7 @@ class Prompt extends Events {
 
     let result = this.state.error || await this.validate(this.value, this.state);
     if (result !== true) {
-      let error = '\n' + this.symbols.pointer + ' ';
+      let error = '  ';
 
       if (typeof result === 'string') {
         error += result.trim();


### PR DESCRIPTION
Thanks for making enquirer!

When validating, the error message contains a symbol, symbol color, & line break that can't be overridden. In my case, I'd like to remove the pointer and not have a line break, so it fits in consistently.

Would you consider removing the imposed styles until this becomes customizable?

<img width="464" src="https://user-images.githubusercontent.com/50032291/154728463-4688e666-d27e-4a38-96de-a6b281f5ed03.png">

