### PR TITLE
docs:remove options link

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ Get started with Enquirer, the most powerful and easy-to-use Node.js library for
   * [Built-in Prompts](#-built-in-prompts)
   * [Custom Prompts](#-custom-prompts)
 - [Key Bindings](#-key-bindings)
-- [Options](#-options)
 - [Release History](#-release-history)
 - [Performance](#-performance)
 - [About](#-about)


### PR DESCRIPTION
no exist `options`