### PR TITLE
fix: ArrayPromptOptions['choices'] should accept a combination of strings or Choice objects

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -34,7 +34,7 @@ interface ArrayPromptOptions extends BasePromptOptions {
     | 'survey'
     | 'list'
     | 'scale'
-  choices: string[] | Choice[]
+  choices: (string | Choice)[]
   maxChoices?: number
   muliple?: boolean
   initial?: number


### PR DESCRIPTION
The backing code for ArrayPrompt works if any individual choice is a string or expanded object, but the typings require all choices to be either a string or Choice object. This PR updates the typings, such that a single element may be expanded as needed.

Fixes: #https://github.com/enquirer/enquirer/issues/202