### PR TITLE
Resolved a problem in which a number passed by return statement inside result() would change to an empty string inside then().

### DIFF
--- a/lib/types/array.js
+++ b/lib/types/array.js
@@ -603,7 +603,7 @@ class ArrayPrompt extends Prompt {
     super.value = value;
   }
   get value() {
-    if (typeof super.value !== 'string' && super.value === this.initial) {
+    if (typeof super.value !== 'string' && super.value === this.initial && this.input !== '') {
       return this.input;
     }
     return super.value;


### PR DESCRIPTION
Nice to meet you!
My name is @lef237 living in Japan and I am using Enquirer.

I am using Enquirer and would like to report a bug I found.

Specifically, when I return numeric data inside `result()` and the numeric value is the same as `this.initial`, even if `this.input` is an empty string `""`, the empty string is passed to `then()`. 

This problem has caused me to have trouble when I want to pass a numeric value from `result()` into `then()`. I wanted to pass a numerical value to be processed, but an empty string was passed, resulting in an error.

Of course, if the number passed by return statement is different from `this.initial`, then the expected number is passed to `then()` without problems. This is predictable behavior.

So I thought of a improvement plan.

I modified the code to safely pass the number passed by `return` inside of `then()`.
This improvement will help Enquirer users to avoid unexpected errors.

I would appreciate it if you could adopt it.

Sincerely.