### PR TITLE
fix: improve handling of multi-line messages

### DIFF
--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -382,7 +382,9 @@ class Prompt extends Events {
   }
 
   get height() {
-    return this.options.rows || utils.height(this.stdout, 25);
+    // @starpit 20221212 handle multi-line messages
+    const nRows = this.options.rows ? this.options.rows.reduce((N, row) => N + row.message.split(/\n/).length, 0) : undefined
+    return nRows || utils.height(this.stdout, 25);
   }
   get width() {
     return this.options.columns || utils.width(this.stdout, 80);


### PR DESCRIPTION
If a select has messages that contain newlines, then `lib/prompt.js`'s calculation of height is incorrect -- it assumes that the number of lines is equal to the number of "rows" (which for a select, is the number of choices; i.e. it assumes one line per choice).

This PR  improves the height calculation in `lib/prompt.js`.

> Note: I realize that this is project is not merging PRs at this point, but I'm putting this out there in case it helps others.