### PR TITLE
fix: improve support for terminal-link in messages

### DIFF
--- a/lib/ansi.js
+++ b/lib/ansi.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const isTerm = process.env.TERM_PROGRAM === 'Apple_Terminal';
-const colors = require('ansi-colors');
+const stripAnsi = require('strip-ansi');
 const utils = require('./utils');
 const ansi = module.exports = exports;
 const ESC = '\u001b[';
@@ -106,7 +106,7 @@ const erase = ansi.erase = {
 
 ansi.clear = (input = '', columns = process.stdout.columns) => {
   if (!columns) return erase.line + cursor.to(0);
-  let width = str => [...colors.unstyle(str)].length;
+  let width = str => [...stripAnsi(str)].length;
   let lines = input.split(/\r?\n/);
   let rows = 0;
   for (let line of lines) {

--- a/lib/interpolate.js
+++ b/lib/interpolate.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const colors = require('ansi-colors');
+const stripAnsi = require('strip-ansi');
 const clean = (str = '') => {
   return typeof str === 'string' ? str.replace(/^['"]|['"]$/g, '') : '';
 };
@@ -184,7 +184,7 @@ module.exports = async prompt => {
 
           state.invalid.delete(key);
           let res = await result(state.values[key], state, item, index);
-          state.output += colors.unstyle(res);
+          state.output += stripAnsi(res);
           continue;
         }
 
@@ -221,7 +221,7 @@ module.exports = async prompt => {
           if (before !== value) {
             value = prompt.styles.underline(value);
           } else {
-            value = prompt.styles.heading(colors.unstyle(value));
+            value = prompt.styles.heading(stripAnsi(value));
           }
         }
 

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Events = require('events');
-const colors = require('ansi-colors');
+const stripAnsi = require('strip-ansi');
 const keypress = require('./keypress');
 const timer = require('./timer');
 const State = require('./state');
@@ -95,8 +95,8 @@ class Prompt extends Events {
 
   sections() {
     let { buffer, input, prompt } = this.state;
-    prompt = colors.unstyle(prompt);
-    let buf = colors.unstyle(buffer);
+    prompt = stripAnsi(prompt);
+    let buf = stripAnsi(buffer);
     let idx = buf.indexOf(prompt);
     let header = buf.slice(0, idx);
     let rest = buf.slice(idx);

--- a/lib/prompts/form.js
+++ b/lib/prompts/form.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const colors = require('ansi-colors');
+const stripAnsi = require('strip-ansi');
 const SelectPrompt = require('./select');
 const placeholder = require('../placeholder');
 
@@ -152,7 +152,7 @@ class FormPrompt extends SelectPrompt {
     let line = () => [indent, indicator, msg + sep, input, help].filter(Boolean).join(' ');
 
     if (state.submitted) {
-      msg = colors.unstyle(msg);
+      msg = stripAnsi(msg);
       input = submitted(input);
       help = '';
       return line();

--- a/lib/prompts/scale.js
+++ b/lib/prompts/scale.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const colors = require('ansi-colors');
+const stripAnsi = require('strip-ansi');
 const ArrayPrompt = require('../types/array');
 const utils = require('../utils');
 
@@ -164,7 +164,7 @@ class LikertScale extends ArrayPrompt {
     let message = await this.resolve(choice.message, this.state, choice, i);
     let scale = await this.renderScale(choice, i);
     let margin = this.margin[1] + this.margin[3];
-    this.scaleLength = colors.unstyle(scale).length;
+    this.scaleLength = stripAnsi(scale).length;
     this.widths[0] = Math.min(this.widths[0], this.width - this.scaleLength - margin.length);
     let msg = utils.wordWrap(message, { width: this.widths[0], newline });
     let lines = msg.split('\n').map(line => pad(line) + this.margin[1]);

--- a/lib/prompts/snippet.js
+++ b/lib/prompts/snippet.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const colors = require('ansi-colors');
+const stripAnsi = require('strip-ansi');
 const interpolate = require('../interpolate');
 const Prompt = require('../prompt');
 
@@ -175,7 +175,7 @@ class SnippetPrompt extends Prompt {
       return super.submit();
     }
 
-    let lines = colors.unstyle(output).split('\n');
+    let lines = stripAnsi(output).split('\n');
     let result = lines.map(v => v.slice(1)).join('\n');
     this.value = { values, result };
     return super.submit();

--- a/lib/types/array.js
+++ b/lib/types/array.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const colors = require('ansi-colors');
+const stripAnsi = require('strip-ansi');
 const Prompt = require('../prompt');
 const roles = require('../roles');
 const utils = require('../utils');
@@ -125,7 +125,7 @@ class ArrayPrompt extends Prompt {
     ele.enabled = !!(this.multiple && !this.isDisabled(ele) && (ele.enabled || this.isSelected(ele)));
 
     if (!this.isDisabled(ele)) {
-      this.longest = Math.max(this.longest, colors.unstyle(ele.message).length);
+      this.longest = Math.max(this.longest, stripAnsi(ele.message).length);
     }
 
     // shallow clone the choice first

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "cover": "nyc --reporter=text --reporter=html mocha"
   },
   "dependencies": {
-    "ansi-colors": "^4.1.1"
+    "ansi-colors": "^4.1.1",
+    "strip-ansi": "^6.0.1"
   },
   "devDependencies": {
     "@types/node": "^8",

--- a/test/prompt.input.js
+++ b/test/prompt.input.js
@@ -2,7 +2,6 @@
 
 require('mocha');
 const assert = require('assert');
-const colors = require('ansi-colors');
 const Prompt = require('../lib/prompts/input');
 const { kepresses } = require('./support')(assert);
 let prompt;

--- a/test/prompt.js
+++ b/test/prompt.js
@@ -1,7 +1,7 @@
 'use strict';
 
 require('mocha');
-const colors = require('ansi-colors');
+const stripAnsi = require('strip-ansi');
 const assert = require('assert');
 const PromptBase = require('../lib/prompt');
 const { timeout } = require('./support')(assert);
@@ -159,9 +159,9 @@ describe('Prompt', function() {
         }
       });
 
-      assert.equal(colors.unstyle(prompt.symbols.separator), '|>');
-      assert.equal(colors.unstyle(prompt.symbols.indicator), 'X');
-      assert.equal(colors.unstyle(prompt.symbols.prefix), '?');
+      assert.equal(stripAnsi(prompt.symbols.separator), '|>');
+      assert.equal(stripAnsi(prompt.symbols.indicator), 'X');
+      assert.equal(stripAnsi(prompt.symbols.prefix), '?');
     });
   });
 });

--- a/test/prompt.multiselect.js
+++ b/test/prompt.multiselect.js
@@ -4,6 +4,7 @@ require('mocha');
 const fs = require('fs');
 const assert = require('assert');
 const colors = require('ansi-colors');
+const stripAnsi = require('strip-ansi');
 const support = require('./support');
 const { timeout, nextTick, expect } = support(assert);
 const MultiSelect = require('../lib/prompts/multiselect');
@@ -108,10 +109,10 @@ describe('multiselect', function() {
       });
 
       prompt.once('run', async() => {
-        let init = colors.unstyle([prompt.symbols.pointer, prompt.options.initial].join(' '));
+        let init = stripAnsi([prompt.symbols.pointer, prompt.options.initial].join(' '));
         await prompt.render();
         try {
-          let buf = colors.unstyle(prompt.state.buffer);
+          let buf = stripAnsi(prompt.state.buffer);
           assert(!buf.includes(init));
           prompt.submit();
           cb();


### PR DESCRIPTION
If a select has messages that contain terminal links (see Anchor in https://iterm2.com/documentation-escape-codes.html), then enquirer's width calculation is incorrect. It uses `ansi-colors.unstyle` to strip off ansi control characters. It appears that that npm does not understand this anchor extension. `strip-ansi` does.

The fix is to switch from `colors.unstyle` to `strip-ansi`

> Note: I realize that this is project is not merging PRs at this point, but I'm putting this out there in case it helps others.