### PR TITLE
fix paste / Chinese phrase wrong render

### DIFF
--- a/lib/keypress.js
+++ b/lib/keypress.js
@@ -2,6 +2,7 @@
 
 const readline = require('readline');
 const combos = require('./combos');
+const Queue = require('./queue');
 
 /* eslint-disable no-control-regex */
 const metaKeyCodeRe = /^(?:\x1b)([a-zA-Z0-9])$/;
@@ -202,16 +203,17 @@ keypress.listen = (options = {}, onKeypress) => {
   let rl = readline.createInterface({ terminal: true, input: stdin });
   readline.emitKeypressEvents(stdin, rl);
 
-  let on = (buf, key) => onKeypress(buf, keypress(buf, key), rl);
+  const queue = new Queue((buf, key) => onKeypress(buf, keypress(buf, key), rl));
   let isRaw = stdin.isRaw;
 
   if (stdin.isTTY) stdin.setRawMode(true);
-  stdin.on('keypress', on);
+  stdin.on('keypress', queue.enqueue);
   rl.resume();
 
   let off = () => {
     if (stdin.isTTY) stdin.setRawMode(isRaw);
-    stdin.removeListener('keypress', on);
+    stdin.removeListener('keypress', queue.enqueue);
+    queue.destroy();
     rl.pause();
     rl.close();
   };

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -1,0 +1,33 @@
+'use strict';
+
+module.exports = class Queue {
+
+    _queue = [];
+    _executing = false;
+    _jobRunner = null;
+
+    constructor(jobRunner) {
+        this._jobRunner = jobRunner;
+    }
+
+    enqueue = (...args) => {
+        this._queue.push(args);
+        this._dequeue();
+    }
+
+    destroy() {
+        this._queue.length = 0;
+        this._jobRunner = null;
+    }
+
+    _dequeue() {
+        if (this._executing || !this._queue.length) return;
+        this._executing = true;
+
+        this._jobRunner(...this._queue.shift());
+        setTimeout(() => {
+            this._executing = false;
+            this._dequeue();
+        });
+    }
+}


### PR DESCRIPTION
fix the duplication of render when paste long words or input Chinese phrase.

let me demo with simple code below

```js
const { Snippet } = require('enquirer');

async function main() {
    const p = new Snippet({
        name: 'Author Name',
        fields: [
            {
                name: 'author_name',   
            }
        ],
        template: `hello \${name}`
    });

    p.run().catch(console.log);
}

main()
```

and paste long word or input Chinese phrase results 

![](https://raw.githubusercontent.com/holynewbie/imgs/master/enquier-demo.webp)

it's beacse nodejs `keypress` event fires too quick but some processes are async, like 

https://github.com/enquirer/enquirer/blob/master/lib/prompts/snippet.js#L123-L149

```js
async render() {
    let { index, keys = [], submitted, size } = this.state;

    let newline = [this.options.newline, '\n'].find(v => v != null);
    let prefix = await this.prefix();
    let separator = await this.separator();
    let message = await this.message();

    let prompt = [prefix, message, separator].filter(Boolean).join(' ');
    this.state.prompt = prompt;

    let header = await this.header();
    let error = (await this.error()) || '';
    let hint = (await this.hint()) || '';
    let body = submitted ? '' : await this.interpolate(this.state);

    let key = this.state.key = keys[index] || '';
    let input = await this.format(key);
    let footer = await this.footer();
    if (input) prompt += ' ' + input;
    if (hint && !input && this.state.completed === 0) prompt += ' ' + hint;

    this.clear(size);
    let lines = [header, prompt, body, footer, error.trim()];
    this.write(lines.filter(Boolean).join(newline));
    this.restore();
  }
```

causing the `body` (in the  `interpolate` ) gets wrong result.

so  I queue the `keypress` event and re-fire them with dome delay using `setTimeout` (wating all micro tasks that using `async`  finish)
