### PR TITLE
fix: duplicate hint in form

### DIFF
--- a/lib/prompts/form.js
+++ b/lib/prompts/form.js
@@ -128,7 +128,6 @@ class FormPrompt extends SelectPrompt {
     let { cursor, initial = '', name, hint, input = '' } = choice;
     let { muted, submitted, primary, danger } = styles;
 
-    let help = hint;
     let focused = this.index === i;
     let validate = choice.validate || (() => true);
     let sep = await this.choiceSeparator(choice, i);
@@ -149,12 +148,12 @@ class FormPrompt extends SelectPrompt {
     let indicator = style(await this.indicator(choice, i)) + (choice.pad || '');
 
     let indent = this.indent(choice);
-    let line = () => [indent, indicator, msg + sep, input, help].filter(Boolean).join(' ');
+    let line = () => [indent, indicator, msg + sep, input ].filter(Boolean).join(' ');
 
     if (state.submitted) {
       msg = colors.unstyle(msg);
       input = submitted(input);
-      help = '';
+
       return line();
     }
 


### PR DESCRIPTION
Remove duplicate hint in form choices