### PR TITLE
fix: syntax incompatibility with Node 12 & 14

### DIFF
--- a/lib/types/string.js
+++ b/lib/types/string.js
@@ -12,7 +12,10 @@ class StringPrompt extends Prompt {
     if (this.initial) this.cursorHide();
     this.state.prevCursor = 0;
     this.state.clipboard = [];
-    this.keypressTimeout = this.options.keypressTimeout ?? null;
+    this.keypressTimeout =
+      this.options.keypressTimeout !== undefined
+        ? this.options.keypressTimeout
+        : null;
   }
 
   async keypress(input, key = input ? keypress(input, {}) : {}) {
@@ -30,7 +33,7 @@ class StringPrompt extends Prompt {
         return this.submit();
       }
 
-      this.state.multilineBuffer ||= '';
+      this.state.multilineBuffer = this.state.multilineBuffer || '';
       this.state.multilineBuffer += input;
       append = true;
       prev = null;


### PR DESCRIPTION
Fix syntax incompatibility with Node 12 & 14, the tests passed in Node v12.22.10 and v14.20.0.

Please refer to #432 and #431 for more details.