### PR TITLE
fix: do not drop value in multi select

### DIFF
--- a/lib/types/array.js
+++ b/lib/types/array.js
@@ -559,7 +559,8 @@ class ArrayPrompt extends Prompt {
       value = utils.reorder(value);
     }
 
-    this.value = multi ? value.map(ch => ch.name) : value.name;
+    const getValue = (ch) => "value" in ch ? ch.value : ch.name;
+    this.value = multi ? value.map(getValue) : getValue(value);
     return super.submit();
   }
 


### PR DESCRIPTION
# Problem

multi-select ignores `value`s in `choices`.

# Solution

Respect `value` if present in a choice, otherwise, fallback to default behavior.