### PR TITLE
docs: acknowledge another dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 Created by [jonschlinkert][jon] and [doowb][brian], Enquirer is fast, easy to use, and lightweight enough for small projects, while also being powerful and customizable enough for the most advanced use cases.
 
 - **Fast** - [Loads in ~4ms](#-performance) (that's about _3-4 times faster than a [single frame of a HD movie](http://www.endmemo.com/sconvert/framespersecondframespermillisecond.php) at 60fps_)
-- **Lightweight** - Only one dependency, the excellent [ansi-colors](https://github.com/doowb/ansi-colors) by [Brian Woodward](https://github.com/doowb).
+- **Lightweight** - Only two dependencies, the excellent [ansi-colors](https://github.com/doowb/ansi-colors) by [Brian Woodward](https://github.com/doowb) and [strip-ansi](https://github.com/chalk/strip-ansi) by [Sindre Sorhus](https://github.com/sindresorhus).
 - **Easy to implement** - Uses promises and async/await and sensible defaults to make prompts easy to create and implement.
 - **Easy to use** - Thrill your users with a better experience! Navigating around input and choices is a breeze. You can even create [quizzes](examples/fun/countdown.js), or [record](examples/fun/record.js) and [playback](examples/fun/play.js) key bindings to aid with tutorials and videos.
 - **Intuitive** - Keypress combos are available to simplify usage.


### PR DESCRIPTION
Was looking at enquirer's dependencies and noticed the readme said there's only one, but there are two listed on https://www.npmjs.com/package/enquirer?activeTab=dependencies