### PR TITLE
types: add a few missing array options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -40,9 +40,14 @@ interface ArrayPromptOptions extends BasePromptOptions {
     | 'list'
     | 'scale'
   choices: (string | Choice)[]
-  maxChoices?: number
+  limit?: number
   multiple?: boolean
+  maxSelected?: number
   initial?: number
+  suggest?: (
+    input: string,
+    choices: (string | Choice)[],
+  ) => (string | Choice)[];
   delay?: number
   separator?: boolean
   sort?: boolean


### PR DESCRIPTION
- `maxChoices` does not exist as an option: the only occurance of this string is in the declarations file. Presumably it's an old name for `limit`?
- Add `limit`, `maxSelected` and `suggest` following how they are used in types/array

This should fix #404 if I've done this correctly.