### PR TITLE
Fix ref to built-in-prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Get started with Enquirer, the most powerful and easy-to-use Node.js library for
 - [Usage](#-usage)
 - [Enquirer](#-enquirer)
 - [Prompts](#-prompts)
-  * [Built-in Prompts](#-built-in-prompts)
+  * [Built-in Prompts](#built-in-prompts)
   * [Custom Prompts](#-custom-prompts)
 - [Key Bindings](#-key-bindings)
 - [Options](#prompt-options)


### PR DESCRIPTION
As the built-in-prompts header is missing the > symbol, the href does not work with the prefix minus.