### PR TITLE
options.loop? array.js

### DIFF
--- a/lib/types/array.js
+++ b/lib/types/array.js
@@ -373,6 +373,10 @@ class ArrayPrompt extends Prompt {
     let len = this.choices.length;
     let vis = this.visible.length;
     let idx = this.index;
+    let gidx = this.choices[idx].index;
+    if (this.options.loop === false && gidx === 0) {
+      return this.alert();
+    }
     if (this.options.scroll === false && idx === 0) {
       return this.alert();
     }
@@ -390,6 +394,10 @@ class ArrayPrompt extends Prompt {
     let len = this.choices.length;
     let vis = this.visible.length;
     let idx = this.index;
+    let gidx = this.choices[idx].index;
+    if (this.options.loop === false && gidx === len - 1) {
+      return this.alert();
+    }
     if (this.options.scroll === false && idx === vis - 1) {
       return this.alert();
     }


### PR DESCRIPTION
I suggest implementing a simple change that would allow users to disable the feature where the selection loops back to the first choice once the bottom of the list is reached. This will provide more control over the navigation behavior and improve user experience, especially when users do not want the selection to automatically reset to the top after reaching the end of the options.